### PR TITLE
Fix cached vectorstore return type

### DIFF
--- a/src/rag/engine.py
+++ b/src/rag/engine.py
@@ -742,14 +742,14 @@ class RAGEngine:
         """
         return self._load_cache_metadata()
 
-    def load_cached_vectorstore(self, file_path: str) -> FAISS:
+    def load_cached_vectorstore(self, file_path: str) -> FAISS | None:
         """Load a cached vectorstore.
 
         Args:
             file_path: Path to the source file
 
         Returns:
-            FAISS vectorstore
+            Loaded FAISS vectorstore or ``None`` if not found
 
         """
         return self._load_cached_vectorstore(file_path)
@@ -763,14 +763,14 @@ class RAGEngine:
         """
         return self.cache_manager.load_cache_metadata()
 
-    def _load_cached_vectorstore(self, file_path: str) -> FAISS:
+    def _load_cached_vectorstore(self, file_path: str) -> FAISS | None:
         """Backward compatibility: Load vectorstore from cache.
 
         Args:
             file_path: Path to the file
 
         Returns:
-            FAISS vectorstore
+            Loaded FAISS vectorstore or ``None`` if not found
 
         """
         return self.vectorstore_manager.load_vectorstore(file_path)

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -150,3 +150,20 @@ def test_initialize_paths(_mock_mkdir: MagicMock) -> None:
 
         # Verify cache directory was created
         _mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
+
+
+@patch.object(RAGEngine, "_initialize_from_config", autospec=True)
+def test_load_cached_vectorstore_none(_mock_initialize: MagicMock) -> None:
+    """Return ``None`` when no cached vectorstore is found."""
+
+    with (
+        patch.object(RAGEngine, "vectorstore_manager", create=True) as mock_vs,
+        patch.object(RAGEngine, "index_manager", create=True, new=MagicMock()),
+    ):
+        mock_vs.load_vectorstore.return_value = None
+
+        engine = RAGEngine()
+        result = engine.load_cached_vectorstore("missing.txt")
+
+        assert result is None
+        mock_vs.load_vectorstore.assert_called_once_with("missing.txt")


### PR DESCRIPTION
## Summary
- return `None` when cached vectorstore is missing
- test that `load_cached_vectorstore` handles missing cache

## Testing
- `python tests/run_tests.py` *(fails: ModuleNotFoundError: No module named 'pytest')*
- `ruff format src/ tests/ --line-length 88`
- `ruff check src/rag tests/unit/test_engine.py --fix --line-length 88`
