### PR TITLE
Fix offline test failures

### DIFF
--- a/src/rag/data/chunking.py
+++ b/src/rag/data/chunking.py
@@ -7,7 +7,6 @@ document types, optimizing for semantic boundaries and metadata preservation.
 import logging
 from typing import Any
 
-import tiktoken
 from langchain_core.documents import Document
 from langchain_text_splitters import (
     MarkdownHeaderTextSplitter,
@@ -19,7 +18,7 @@ from langchain_text_splitters import (
 from rag.ingest import ChunkingStrategy
 from rag.utils.logging_utils import log_message
 
-from .text_splitter import TextSplitterFactory
+from .text_splitter import TextSplitterFactory, _DummyEncoding, _safe_encoding_for_model
 
 logger = logging.getLogger(__name__)
 
@@ -51,13 +50,7 @@ class DefaultChunkingStrategy(ChunkingStrategy):
         self.log_callback = log_callback
 
         # Initialize tokenizer
-        try:
-            self.tokenizer = tiktoken.encoding_for_model(model_name)
-        except KeyError:
-            logger.warning(
-                f"Model {model_name} not found, falling back to cl100k_base encoding"
-            )
-            self.tokenizer = tiktoken.get_encoding("cl100k_base")
+        self.tokenizer = _safe_encoding_for_model(model_name)
 
     def _log(self, level: str, message: str) -> None:
         """Log a message.
@@ -222,6 +215,13 @@ class DefaultChunkingStrategy(ChunkingStrategy):
         Returns:
             Token-based text splitter
         """
+        if isinstance(self.tokenizer, _DummyEncoding):
+            return RecursiveCharacterTextSplitter(
+                chunk_size=self.chunk_size,
+                chunk_overlap=self.chunk_overlap,
+                length_function=lambda text: len(self.tokenizer.encode(text)),
+            )
+
         return TokenTextSplitter(
             encoding_name=self.tokenizer.name,
             chunk_size=self.chunk_size,


### PR DESCRIPTION
## Summary
- avoid network access in text splitting by providing a fallback tokenizer
- use that safe tokenizer in chunking and text splitter utilities

## Testing
- `./check.sh`