### PR TITLE
Add logging tests with fallback support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `summarize`: Table of document summaries
     - `cleanup`: Summary of removed files
     - `invalidate`: Success/error messages
+- Structured logging using structlog with Rich console output
   - Consistent error output format across all commands
   - Integration with tools like `jq` for output processing
   - Comprehensive test suite for JSON output functionality

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,5 @@
 ## 🚀 Next Up (Implementation Plan)
 
-### 1. **Structured Logging**
-In addition to structured (json) command output, let's use structlog to produce structured logging. logs emitted to the console should be pretty-printed in rich text, but logs emitted to a file or with the --json flag active should be in JSON format
-
-
 ---
 
 ## 🗺️ Roadmap & Priorities  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "rich>=13.7.0",
     "textual>=3.2.0,<4.0.0",
     "prompt_toolkit>=3.0.43",
+    "structlog>=24.1.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/rag/utils/logging_utils.py
+++ b/src/rag/utils/logging_utils.py
@@ -1,51 +1,109 @@
 """Logging utilities for the RAG system.
 
-This module provides centralized logging functionality for the RAG system,
-including console and file logging.
+This module configures structured logging using structlog. Console logs are
+pretty-printed with Rich, while logs written to file or emitted when JSON mode
+is active are rendered as JSON.
 """
+
+from __future__ import annotations
 
 import logging
 from collections.abc import Callable
 
-# Configure logger
-logger = logging.getLogger("rag")
+try:
+    import structlog
+except ModuleNotFoundError:  # pragma: no cover - structlog may be missing
+    structlog = None  # type: ignore[assignment]
 
-# Set our main logger to INFO and allow propagation
-logger.setLevel(logging.INFO)
-logger.propagate = True  # Allow propagation to root logger
+from rich.console import Console
+from rich.logging import RichHandler
+
+logger: logging.Logger
+if structlog is not None:
+    logger = structlog.get_logger("rag")
+else:  # Fallback to standard logging when structlog is unavailable
+    logger = logging.getLogger("rag")
 
 
-def setup_logging(log_file: str = "rag.log", log_level: int = logging.INFO) -> None:
-    """Set up logging for the RAG system.
+def setup_logging(
+    log_file: str = "rag.log",
+    log_level: int = logging.INFO,
+    json_logs: bool = False,
+) -> None:
+    """Configure structlog and standard logging.
 
     Args:
-        log_file: Path to the log file
-        log_level: Logging level (e.g., logging.INFO, logging.DEBUG)
-
+        log_file: Path to the log file.
+        log_level: Logging level.
+        json_logs: Emit JSON logs to the console if True.
     """
-    # Configure root logger
     root_logger = logging.getLogger()
     root_logger.setLevel(log_level)
+    root_logger.handlers = []
 
-    # Remove any existing handlers
-    for handler in root_logger.handlers[:]:
-        root_logger.removeHandler(handler)
+    if structlog is None:
+        formatter_str = (
+            '{"timestamp":%(asctime)s,"level":%(levelname)s,"message":%(message)s}'
+            if json_logs
+            else "%(levelname)s: %(message)s"
+        )
+        formatter = logging.Formatter(formatter_str)
 
-    # Add file handler for log_file
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+
+        console_handler = RichHandler(
+            console=Console(stderr=True), rich_tracebacks=True
+        )
+        console_handler.setFormatter(formatter)
+        root_logger.addHandler(console_handler)
+        return
+
+    timestamper = structlog.processors.TimeStamper(fmt="iso")
+    pre_chain = [structlog.stdlib.add_log_level, timestamper]
+
     file_handler = logging.FileHandler(log_file)
     file_handler.setFormatter(
-        logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"),
+        structlog.stdlib.ProcessorFormatter(
+            processor=structlog.processors.JSONRenderer(),
+            foreign_pre_chain=pre_chain,
+        ),
     )
     root_logger.addHandler(file_handler)
 
+    console_processor = (
+        structlog.processors.JSONRenderer()
+        if json_logs
+        else structlog.dev.ConsoleRenderer()
+    )
+    console_handler = RichHandler(console=Console(stderr=True), rich_tracebacks=True)
+    console_handler.setFormatter(
+        structlog.stdlib.ProcessorFormatter(
+            processor=console_processor,
+            foreign_pre_chain=pre_chain,
+        ),
+    )
+    root_logger.addHandler(console_handler)
+
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            timestamper,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.make_filtering_bound_logger(log_level),
+        cache_logger_on_first_use=True,
+    )
+
 
 def get_logger() -> logging.Logger:
-    """Get the RAG logger.
-
-    Returns:
-        The configured RAG logger
-
-    """
+    """Get the configured RAG logger."""
     return logger
 
 
@@ -55,37 +113,20 @@ def log_message(
     subsystem: str = "RAG",
     callback: Callable[[str, str, str], None] | None = None,
 ) -> None:
-    """Log a message using the Python logger and optionally send to a callback.
-
-    Always writes to rag.log file.
-
-    Args:
-        level: Log level (INFO, WARNING, ERROR, etc.)
-        message: The log message
-        subsystem: The subsystem generating the log
-                   (e.g., "RAG", "Embeddings", "Cache", etc.)
-        callback: Optional callback function for logging
-
-    """
-    formatted_message = f"[{subsystem}] {message}"
+    """Log a message and optionally send it to a callback."""
     log_level = getattr(logging, level.upper(), logging.INFO)
-    # Use %-formatting for the logger itself if it were a direct call like logger.info()
-    # Since we are using logger.log() with a pre-formatted message, G004 doesn't directly apply here
-    # but the f-string for formatted_message is fine.
-    logger.log(log_level, formatted_message)
+    if structlog is not None:
+        logger.bind(subsystem=subsystem).log(log_level, message)
+    else:
+        logger.log(log_level, f"[{subsystem}] {message}")
 
-    # If a callback is provided, send the log message to it
     if callback:
         try:
             callback(level, message, subsystem)
-        except TypeError as e:  # More specific for callback signature issues
+        except TypeError as exc:
             logger.warning(
-                "Failed to send log to callback due to TypeError: %s. "
-                "Check callback signature.",
-                e,
+                "Failed to send log to callback due to TypeError",
+                error=str(exc),
             )
-        except (
-            ValueError,
-            KeyError,
-        ) as e:  # Catch other specific exceptions from the callback
-            logger.warning("Failed to send log to callback: %s", e)
+        except (ValueError, KeyError) as exc:
+            logger.warning("Failed to send log to callback", error=str(exc))

--- a/tests/unit/utils/test_logging_utils.py
+++ b/tests/unit/utils/test_logging_utils.py
@@ -1,0 +1,158 @@
+"""Tests for logging utilities to verify JSON and Rich logging."""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import logging
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+
+def _make_structlog_stub() -> ModuleType:
+    """Create a minimal structlog stub for testing."""
+    stub = ModuleType("structlog")
+
+    class BoundLogger(logging.Logger):
+        def bind(self, **_kwargs: Any) -> "BoundLogger":
+            return self
+
+    def get_logger(name: str = "rag") -> BoundLogger:
+        logger = logging.getLogger(name)
+        if not isinstance(logger, BoundLogger):
+            logger.__class__ = BoundLogger  # type: ignore[assignment]
+        return logger  # type: ignore[return-value]
+
+    class JSONRenderer:
+        def __call__(self, _logger: Any, _name: str, event_dict: dict[str, Any]) -> str:
+            return json.dumps(event_dict)
+
+    class ConsoleRenderer:
+        def __call__(self, _logger: Any, _name: str, event_dict: dict[str, Any]) -> str:
+            return str(event_dict)
+
+    class TimeStamper:
+        def __init__(self, fmt: str = "iso") -> None:
+            self.fmt = fmt
+
+        def __call__(
+            self, _logger: Any, _name: str, event_dict: dict[str, Any]
+        ) -> dict[str, Any]:
+            event_dict["timestamp"] = "1970-01-01T00:00:00"
+            return event_dict
+
+    class ProcessorFormatter(logging.Formatter):
+        def __init__(
+            self, processor: Any, foreign_pre_chain: list[Any] | None = None
+        ) -> None:
+            super().__init__()
+            self.processor = processor
+            self.pre = foreign_pre_chain or []
+
+        def format(self, record: logging.LogRecord) -> str:
+            event_dict = {"event": record.getMessage(), "level": record.levelname}
+            for proc in self.pre:
+                event_dict = proc(None, record.name, event_dict)
+            return self.processor(None, record.name, event_dict)
+
+        @staticmethod
+        def wrap_for_formatter(
+            _logger: Any, _name: str, event_dict: dict[str, Any]
+        ) -> dict[str, Any]:
+            return event_dict
+
+    class LoggerFactory:
+        pass
+
+    class StdLib(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("stdlib")
+            self.add_log_level = lambda _l, _n, d: d
+            self.add_logger_name = lambda _l, _n, d: d
+            self.filter_by_level = lambda _l, _n, d: d
+            self.ProcessorFormatter = ProcessorFormatter
+            self.LoggerFactory = LoggerFactory
+
+    class Processors(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("processors")
+            self.TimeStamper = TimeStamper
+            self.JSONRenderer = JSONRenderer
+            self.StackInfoRenderer = lambda: (lambda l, n, d: d)
+            self.format_exc_info = lambda l, n, d: d
+
+    class Dev(ModuleType):
+        def __init__(self) -> None:
+            super().__init__("dev")
+            self.ConsoleRenderer = ConsoleRenderer
+
+    stub.BoundLogger = BoundLogger
+    stub.get_logger = get_logger
+    stub.processors = Processors()
+    stub.stdlib = StdLib()
+    stub.dev = Dev()
+    stub.make_filtering_bound_logger = lambda _lvl: BoundLogger
+    stub.configure = lambda **_kw: None
+
+    return stub
+
+
+def _import_logging_utils() -> ModuleType:
+    """Import logging_utils with the structlog stub injected."""
+    structlog_stub = _make_structlog_stub()
+    sys.modules["structlog"] = structlog_stub
+
+    spec = importlib.util.spec_from_file_location(
+        "logging_utils",
+        Path(__file__).resolve().parents[3] / "src/rag/utils/logging_utils.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _setup_and_log(json_logs: bool) -> tuple[str, str]:
+    """Configure logging and capture console and file output."""
+    logging_utils = _import_logging_utils()
+
+    stream = io.StringIO()
+    file_stream = io.StringIO()
+
+    def console_factory(stderr: bool = False) -> Console:  # noqa: ARG001
+        return Console(file=stream, force_terminal=True, width=80)
+
+    class FileHandler(logging.StreamHandler):
+        def __init__(self) -> None:
+            super().__init__(file_stream)
+
+    logging_utils.Console = console_factory  # type: ignore[assignment]
+    logging_utils.logging.FileHandler = lambda _path: FileHandler()  # type: ignore
+
+    logging_utils.setup_logging(log_file="dummy.log", json_logs=json_logs)
+    logger = logging_utils.get_logger()
+    logger.info("test message", subsystem="test")
+
+    return stream.getvalue().strip(), file_stream.getvalue().strip()
+
+
+def test_json_logs_are_json() -> None:
+    """Ensure logs are JSON-formatted in JSON mode."""
+    console_out, file_out = _setup_and_log(json_logs=True)
+    assert json.loads(console_out)
+    assert json.loads(file_out)
+
+
+def test_rich_logs_in_plain_mode() -> None:
+    """Ensure logs are not JSON when JSON mode is disabled."""
+    console_out, file_out = _setup_and_log(json_logs=False)
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(console_out)
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(file_out)


### PR DESCRIPTION
## Summary
- handle missing structlog gracefully in logging utils and CLI
- add tests for logging modes

## Testing
- `./check.sh` *(fails: FileNotFoundError for logging_utils and test failures)*