### PR TITLE
Add secure manual integration test workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,11 +2,10 @@ name: Integration Tests
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 0'
 
 jobs:
   integration:
+    if: ${{ github.actor == secrets.INTEGRATION_ACTOR }}
     runs-on: ubuntu-latest
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -374,8 +374,19 @@ Each command produces structured JSON output:
        "tokens_used": 150,
        "model": "gpt-4"
      }
-   }
-   ```
+  }
+  ```
+
+## GitHub Integration Tests
+
+Integration tests can be run in GitHub Actions. The workflow is triggered
+manually and requires two repository secrets:
+
+1. `OPENAI_API_KEY` – your OpenAI API key used by the tests.
+2. `INTEGRATION_ACTOR` – the GitHub username allowed to run the workflow.
+
+Head to **Actions → Integration Tests** and choose **Run workflow** to start a
+test run.
 
 ## License
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -22,6 +22,17 @@ To run the integration tests manually:
 ./tests/run_integration_tests.py --cache-dir /path/to/custom/cache
 ```
 
+## Running on GitHub
+
+This repository includes an **Integration Tests** workflow that runs the same
+commands in GitHub Actions. The workflow is triggered manually and only starts
+when the actor matches the `INTEGRATION_ACTOR` secret.
+
+1. Add your OpenAI key as a repository secret named `OPENAI_API_KEY`.
+2. Add another secret `INTEGRATION_ACTOR` set to your GitHub username.
+3. Go to **Actions → Integration Tests** and click **Run workflow** to launch
+   the tests.
+
 ## Test Selection
 
 The integration tests directory contains two types of tests:


### PR DESCRIPTION
## Summary
- limit integration test workflow to a single actor
- document running integration tests via GitHub Actions

## Testing
- `./check.sh`