### PR TITLE
Use pytest-socket to block network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Network isolation for unit tests using `pytest-socket`
 - Machine-readable JSON output for all CLI commands:
   - Added `--json` flag to enable JSON output
   - Auto-detect non-TTY stdout for automatic JSON mode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ Run the full quality assurance suite before committing changes:
 ```
 This script formats the code, runs the linter, and executes the unit tests via `tests/run_tests.py`.
 
+### Network isolation
+
+Unit tests run with network access disabled using `pytest-socket`. If a test
+needs network access, mark it with `@pytest.mark.integration` and run it via
+`tests/run_integration_tests.py`.
+
 ## Git Workflow
 
 - Use feature branches for your work and keep them short-lived.

--- a/README.md
+++ b/README.md
@@ -374,8 +374,15 @@ Each command produces structured JSON output:
        "tokens_used": 150,
        "model": "gpt-4"
      }
-  }
+ }
   ```
+
+## Running Tests
+
+Execute `./check.sh` to format, lint, and run the unit tests. Network access is
+disabled by default using `pytest-socket`. Tests that require the network should
+be marked with `@pytest.mark.integration` and run with
+`tests/run_integration_tests.py`.
 
 ## GitHub Integration Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pre-commit>=3.6.0",
     "pytest>=8.3.0",
     "pytest-cov>=6.1.0",
+    "pytest-socket>=0.6.0",
     "hatch>=1.9.0"
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from langchain_openai import OpenAIEmbeddings
 
 from rag.config import RAGConfig, RuntimeOptions
 from rag.embeddings.embedding_provider import EmbeddingProvider
+from pytest_socket import disable_socket, enable_socket
 
 
 # Define the integration marker - tests with this marker are not run by default
@@ -23,6 +24,17 @@ def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers", "integration: mark test as integration test (not run by default)"
     )
+
+
+@pytest.fixture(autouse=True)
+def disable_network(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+    """Disable network access for tests unless marked as integration."""
+    if "integration" not in request.keywords:
+        disable_socket()
+        yield
+        enable_socket()
+    else:
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- block network access in tests unless marked integration
- document network isolation in CONTRIBUTING and README
- add pytest-socket as a dev dependency
- note new test behaviour in CHANGELOG

## Testing
- `./check.sh` *(fails: ModuleNotFoundError: No module named 'pytest_socket')*