### PR TITLE
Improve logging defaults

### DIFF
--- a/tests/unit/utils/test_logging_utils.py
+++ b/tests/unit/utils/test_logging_utils.py
@@ -145,7 +145,7 @@ def _setup_and_log(json_logs: bool) -> tuple[str, str]:
 def test_json_logs_are_json() -> None:
     """Ensure logs are JSON-formatted in JSON mode."""
     console_out, file_out = _setup_and_log(json_logs=True)
-    assert json.loads(console_out)
+    assert console_out == ""
     assert json.loads(file_out)
 
 


### PR DESCRIPTION
## Summary
- tweak RAGLogger to preserve original call site
- add demotion filter for noisy http and pdf logs
- restructure console renderer and handlers
- show subsystem/logger in output and trim timestamp precision
- only show errors on console when JSON mode is active
- update tests for new behaviour

## Testing
- `./check.sh`