### PR TITLE
Improve logging defaults

### DIFF
--- a/src/rag/utils/logging_utils.py
+++ b/src/rag/utils/logging_utils.py
@@ -39,27 +39,35 @@ class RAGLogger:
         """Log a message with optional subsystem context."""
         extra = kwargs.pop("extra", {})
         extra["subsystem"] = subsystem
-        self._base_logger.log(level, msg, *args, extra=extra, **kwargs)
+        stacklevel = kwargs.pop("stacklevel", 1)
+        self._base_logger.log(
+            level,
+            msg,
+            *args,
+            extra=extra,
+            stacklevel=stacklevel + 1,
+            **kwargs,
+        )
 
     def debug(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Delegate ``DEBUG`` messages."""
-        self.log(logging.DEBUG, msg, *args, **kwargs)
+        self.log(logging.DEBUG, msg, *args, stacklevel=2, **kwargs)
 
     def info(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Delegate ``INFO`` messages."""
-        self.log(logging.INFO, msg, *args, **kwargs)
+        self.log(logging.INFO, msg, *args, stacklevel=2, **kwargs)
 
     def warning(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Delegate ``WARNING`` messages."""
-        self.log(logging.WARNING, msg, *args, **kwargs)
+        self.log(logging.WARNING, msg, *args, stacklevel=2, **kwargs)
 
     def error(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Delegate ``ERROR`` messages."""
-        self.log(logging.ERROR, msg, *args, **kwargs)
+        self.log(logging.ERROR, msg, *args, stacklevel=2, **kwargs)
 
     def critical(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Delegate ``CRITICAL`` messages."""
-        self.log(logging.CRITICAL, msg, *args, **kwargs)
+        self.log(logging.CRITICAL, msg, *args, stacklevel=2, **kwargs)
 
     def exception(self, msg: str, *args: Any, **kwargs: Any) -> None:
         """Delegate ``ERROR`` messages with exception info."""
@@ -91,17 +99,54 @@ def setup_logging(
     root_logger.setLevel(log_level)
     root_logger.handlers = []
 
-    def _console_renderer():
+    http_loggers = ["httpx", "urllib3", "requests"]
+    pdf_loggers = ["pdfminer", "unstructured"]
+
+    class DemoteFilter(logging.Filter):
+        def filter(self, record: logging.LogRecord) -> bool:
+            """Demote noisy logs to DEBUG or drop them."""
+            name = record.name.split(".")[0]
+            if name in http_loggers and record.levelno == logging.INFO:
+                record.levelno = logging.DEBUG
+                record.levelname = "DEBUG"
+                return logging.getLogger(record.name).isEnabledFor(record.levelno)
+            if name in pdf_loggers and record.levelno == logging.WARNING:
+                record.levelno = logging.DEBUG
+                record.levelname = "DEBUG"
+                return logging.getLogger(record.name).isEnabledFor(record.levelno)
+            return True
+
+    root_logger.addFilter(DemoteFilter())
+
+    def _console_renderer() -> structlog.dev.ConsoleRenderer:
         try:
             params = inspect.signature(structlog.dev.ConsoleRenderer).parameters
+            kwargs: dict[str, Any] = {}
             if "colors" in params:
-                return structlog.dev.ConsoleRenderer(colors=False)
+                kwargs["colors"] = False
+            if "sort_keys" in params:
+                kwargs["sort_keys"] = False
+            if "key_order" in params:
+                kwargs["key_order"] = ["timestamp", "level", "logger", "event"]
+            return structlog.dev.ConsoleRenderer(**kwargs)
         except (ValueError, TypeError):  # pragma: no cover - stub compatibility
-            pass
-        return structlog.dev.ConsoleRenderer()
+            return structlog.dev.ConsoleRenderer()
 
-    timestamper = structlog.processors.TimeStamper(fmt="iso")
-    pre_chain = [structlog.stdlib.add_log_level, timestamper]
+    def _upper_level(
+        _logger: Any, _name: str, event_dict: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Normalize log level to uppercase."""
+        if "level" in event_dict:
+            event_dict["level"] = str(event_dict["level"]).upper()
+        return event_dict
+
+    timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S")
+    pre_chain = [
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        timestamper,
+        _upper_level,
+    ]
 
     file_processor = (
         structlog.processors.JSONRenderer() if json_logs else _console_renderer()
@@ -115,14 +160,41 @@ def setup_logging(
     )
     root_logger.addHandler(file_handler)
 
+    def _colorize_level(level: str) -> str:
+        color_map = {
+            "CRITICAL": "bold red",
+            "ERROR": "red",
+            "WARNING": "yellow",
+            "INFO": "green",
+            "DEBUG": "cyan",
+        }
+        color = color_map.get(level, "white")
+        return f"[{color}]{level}[/]"
+
+    def _console_processor(logger: Any, name: str, event_dict: dict[str, Any]) -> str:
+        level = event_dict.get("level", "")
+        if level:
+            event_dict["level"] = _colorize_level(str(level))
+        event_dict["logger"] = event_dict.get("logger") or event_dict.get(
+            "subsystem",
+            name,
+        )
+        return _console_renderer()(logger, name, event_dict)
+
     console_processor = (
-        structlog.processors.JSONRenderer() if json_logs else _console_renderer()
+        _console_processor if not json_logs else structlog.processors.JSONRenderer()
     )
     console = Console(stderr=True)
     if json_logs:
         console_handler = logging.StreamHandler(console.file)
+        console_handler.setLevel(logging.ERROR)
     else:
-        console_handler = RichHandler(console=console, rich_tracebacks=True)
+        console_handler = RichHandler(
+            console=console,
+            rich_tracebacks=True,
+            show_level=False,
+            show_time=False,
+        )
     console_handler.setFormatter(
         structlog.stdlib.ProcessorFormatter(
             processor=console_processor,
@@ -160,7 +232,7 @@ def log_message(
 ) -> None:
     """Log a message and optionally send it to a callback."""
     log_level = getattr(logging, level.upper(), logging.INFO)
-    logger.log(log_level, message, subsystem=subsystem)
+    logger.log(log_level, message, subsystem=subsystem, stacklevel=3)
 
     if callback:
         try:

--- a/tests/unit/utils/test_logging_utils.py
+++ b/tests/unit/utils/test_logging_utils.py
@@ -145,7 +145,7 @@ def _setup_and_log(json_logs: bool) -> tuple[str, str]:
 def test_json_logs_are_json() -> None:
     """Ensure logs are JSON-formatted in JSON mode."""
     console_out, file_out = _setup_and_log(json_logs=True)
-    assert json.loads(console_out)
+    assert console_out == ""
     assert json.loads(file_out)
 
 


### PR DESCRIPTION
## Summary
- tweak RAGLogger to preserve original call site
- add demotion filter for noisy http and pdf logs
- restructure console renderer and handlers
- show subsystem/logger in output and trim timestamp precision
- only show errors on console when JSON mode is active
- update tests for new behaviour
- uppercase log level and colorize in console output
- show logger name after level, falling back to subsystem

## Testing
- `./check.sh`