### PR TITLE
Fix colorization for local and external loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Log levels are now shown in uppercase for better readability
+- Log level output is colorized according to severity
 - Refactored `TextSplitterFactory` to use a table-driven approach for better maintainability
 - Enhanced PDF processing with improved font analysis for heading detection
 - Separated metadata extraction into dedicated `DocumentMetadataExtractor` classes

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 ## 🚀 Next Up (Implementation Plan)
 
 1. Logging fixes:
-1.2 Colorize the log level according to severity (eg, ERROR = red)
 1.3 Put the logger_name immediately after the level. If there is no logger_name, use the subsystem instead
 1.4 The http requests from httpx and the warnings from pdfminer are still appearing by default
 


### PR DESCRIPTION
## Notes
- None

## Summary
- use a console attribute to control level coloring
- enable colorization processor for structlog loggers
- test colorized output from foreign loggers

## Testing
- `./check.sh`