### PR TITLE
Implement log level colorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Log levels are now shown in uppercase for better readability
+- Log level output is colorized according to severity
 - Refactored `TextSplitterFactory` to use a table-driven approach for better maintainability
 - Enhanced PDF processing with improved font analysis for heading detection
 - Separated metadata extraction into dedicated `DocumentMetadataExtractor` classes

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,6 @@
 ## 🚀 Next Up (Implementation Plan)
 
 1. Logging fixes:
-1.2 Colorize the log level according to severity (eg, ERROR = red)
 1.3 Put the logger_name immediately after the level. If there is no logger_name, use the subsystem instead
 1.4 The http requests from httpx and the warnings from pdfminer are still appearing by default
 

--- a/src/rag/utils/logging_utils.py
+++ b/src/rag/utils/logging_utils.py
@@ -93,6 +93,37 @@ def uppercase_level(
     return event_dict
 
 
+LEVEL_STYLES: dict[str, str] = {
+    "CRITICAL": "bold red",
+    "ERROR": "red",
+    "WARNING": "yellow",
+    "INFO": "cyan",
+    "DEBUG": "green",
+}
+
+
+def make_colorize_level(
+    console: Console,
+) -> Callable[[logging.Logger, str, dict[str, Any]], dict[str, Any]]:
+    """Create a processor that colorizes the ``level`` field with ANSI codes."""
+
+    def colorize_level(
+        _logger: logging.Logger, _name: str, event_dict: dict[str, Any]
+    ) -> dict[str, Any]:
+        level = event_dict.get("level")
+        if (
+            isinstance(level, str)
+            and console.is_terminal
+            and console.color_system is not None
+        ):
+            style = LEVEL_STYLES.get(level.upper())
+            if style:
+                event_dict["level"] = console.get_style(style).render(level)
+        return event_dict
+
+    return colorize_level
+
+
 def setup_logging(
     log_file: str = "rag.log",
     log_level: int = logging.INFO,
@@ -148,6 +179,10 @@ def setup_logging(
         timestamper,
     ]
 
+    console = Console(stderr=True)
+    colorize_level = make_colorize_level(console)
+    console_pre_chain = [*pre_chain, colorize_level]
+
     file_processor = (
         structlog.processors.JSONRenderer() if json_logs else _console_renderer()
     )
@@ -163,7 +198,6 @@ def setup_logging(
     console_processor = (
         structlog.processors.JSONRenderer() if json_logs else _console_renderer()
     )
-    console = Console(stderr=True)
     if json_logs:
         console_handler = logging.StreamHandler(console.file)
         console_handler.setLevel(logging.ERROR)
@@ -177,7 +211,7 @@ def setup_logging(
     console_handler.setFormatter(
         structlog.stdlib.ProcessorFormatter(
             processor=console_processor,
-            foreign_pre_chain=pre_chain,
+            foreign_pre_chain=console_pre_chain,
         ),
     )
     root_logger.addHandler(console_handler)
@@ -188,6 +222,7 @@ def setup_logging(
             structlog.stdlib.add_logger_name,
             structlog.stdlib.add_log_level,
             uppercase_level,
+            colorize_level,
             timestamper,
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,

--- a/tests/unit/utils/test_logging_utils.py
+++ b/tests/unit/utils/test_logging_utils.py
@@ -6,6 +6,7 @@ import importlib.util
 import io
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -163,3 +164,15 @@ def test_log_level_uppercase() -> None:
     _, file_out = _setup_and_log(json_logs=True)
     record = json.loads(file_out)
     assert record["level"] == "INFO"
+
+
+def test_log_level_colorized() -> None:
+    """Ensure log levels are colorized without markup artifacts."""
+    console_out, _ = _setup_and_log(json_logs=False)
+    assert "INFO" in console_out
+    # Output should contain ANSI escape codes but no Rich markup
+    assert "\x1b[" in console_out
+    assert "[cyan]" not in console_out
+    assert "[[cyan]" not in console_out
+    assert "[bold red]" not in console_out
+    assert "[/" not in console_out


### PR DESCRIPTION
## Notes
- None

## Summary
- colorize log levels using ANSI escape codes
- document colorized log levels in changelog
- remove completed TODO item for colorizing log levels
- test that log level output is colorized without stray markup

## Testing
- `./check.sh`