### PR TITLE
Fix log colorization

### DIFF
--- a/src/rag/utils/logging_utils.py
+++ b/src/rag/utils/logging_utils.py
@@ -202,6 +202,7 @@ def setup_logging(
             rich_tracebacks=True,
             show_level=False,
             show_time=False,
+            markup=True,
         )
     console_handler.setFormatter(
         structlog.stdlib.ProcessorFormatter(


### PR DESCRIPTION
## Summary
- enable Rich markup for console log handler so colorized levels are converted to ANSI codes

## Testing
- `./check.sh tests/unit/utils/test_logging_utils.py`