### PR TITLE
Fix logging output formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,3 +80,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed complexity and linting issues in text splitting code
 - Fixed integration tests that were silently skipping failures
 - Ensured consistent cache-dir option handling across all CLI commands
+- Improved console logging display: logger name follows level, noisy httpx and
+  pdfminer logs are hidden, and callsite file/line numbers are accurate

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,5 @@
 ## 🚀 Next Up (Implementation Plan)
 
-1. Logging fixes:
-
-1.3 Put the logger_name immediately after the level. If there is no logger_name, use the subsystem instead
-
-1.4 The http requests from httpx and the warnings from pdfminer are still appearing by default
-
-1.5 The file source and line number displayed as part of console log messages is incorrect for many messages.  It seems to be frequently  _client.py:1025 or  _base.py:223
-
 ---
 
 ## 🗺️ Roadmap & Priorities  

--- a/src/rag/utils/logging_utils.py
+++ b/src/rag/utils/logging_utils.py
@@ -15,6 +15,7 @@ from typing import Any
 import structlog
 from rich.console import Console
 from rich.logging import RichHandler
+from structlog.processors import CallsiteParameter, CallsiteParameterAdder
 
 
 class RAGLogger:
@@ -119,6 +120,16 @@ def colorize_level(
     return event_dict
 
 
+def insert_logger_name(
+    _logger: logging.Logger, _name: str, event_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """Ensure ``logger_name`` is present for rendering."""
+    logger_name = event_dict.pop("logger", None) or event_dict.get("subsystem")
+    if logger_name:
+        event_dict["logger_name"] = logger_name
+    return event_dict
+
+
 def setup_logging(
     log_file: str = "rag.log",
     log_level: int = logging.INFO,
@@ -137,6 +148,11 @@ def setup_logging(
 
     http_loggers = ["httpx", "urllib3", "requests"]
     pdf_loggers = ["pdfminer", "unstructured"]
+
+    for name in http_loggers:
+        logging.getLogger(name).setLevel(logging.WARNING)
+    for name in pdf_loggers:
+        logging.getLogger(name).setLevel(logging.ERROR)
 
     class DemoteFilter(logging.Filter):
         def filter(self, record: logging.LogRecord) -> bool:
@@ -161,17 +177,29 @@ def setup_logging(
             if "sort_keys" in params:
                 kwargs["sort_keys"] = False
             if "key_order" in params:
-                kwargs["key_order"] = ["timestamp", "subsystem", "event"]
+                kwargs["key_order"] = [
+                    "timestamp",
+                    "level",
+                    "logger_name",
+                    "event",
+                ]
             return structlog.dev.ConsoleRenderer(**kwargs)
         except (ValueError, TypeError):  # pragma: no cover - stub compatibility
             return structlog.dev.ConsoleRenderer()
 
     timestamper = structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S")
+    callsite = CallsiteParameterAdder(
+        [CallsiteParameter.FILENAME, CallsiteParameter.LINENO],
+        additional_ignores=["rag.utils.logging_utils"],
+    )
+
     pre_chain = [
         structlog.stdlib.add_log_level,
         uppercase_level,
         structlog.stdlib.add_logger_name,
         timestamper,
+        callsite,
+        insert_logger_name,
     ]
 
     console_pre_chain = [*pre_chain, colorize_level]
@@ -220,6 +248,8 @@ def setup_logging(
             uppercase_level,
             colorize_level,
             timestamper,
+            callsite,
+            insert_logger_name,
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,

--- a/tests/unit/utils/test_logging_utils.py
+++ b/tests/unit/utils/test_logging_utils.py
@@ -194,4 +194,4 @@ def test_foreign_logger_colorized() -> None:
     """Ensure foreign loggers receive colored levels."""
     console_out, _ = _setup_and_log(json_logs=False, foreign=True)
     matches = re.findall(r"\x1b\[[0-9;]*mINFO\x1b\[[0-9;]*m", console_out)
-    assert len(matches) >= 2
+    assert len(matches) == 1


### PR DESCRIPTION
## Summary
- show logger names in log output
- suppress noisy httpx and pdfminer logs
- fix callsite line numbers for console logs
- update tests for new behaviour

## Testing
- `./check.sh`