### PR TITLE
Fix failing FastAPI tests

### DIFF
--- a/src/rag/mcp_server.py
+++ b/src/rag/mcp_server.py
@@ -10,17 +10,23 @@ from __future__ import annotations
 from typing import Any
 
 from fastapi import FastAPI
+from pydantic import BaseModel
 
 app = FastAPI(title="RAG MCP Server")
 
 
+class QueryRequest(BaseModel):
+    """Request body for the ``/query`` endpoint."""
+
+    question: str
+    top_k: int | None = None
+    filters: dict[str, Any] | None = None
+
+
 @app.post("/query")
-async def query_endpoint(
-    question: str,
-    top_k: int | None = None,
-    filters: dict[str, Any] | None = None,
-) -> dict[str, Any]:
+async def query_endpoint(request: QueryRequest) -> dict[str, Any]:
     """Handle RAG query requests."""
+    _ = request
     return {"detail": "Not implemented"}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ def pytest_configure(config: pytest.Config) -> None:
 def disable_network(request: pytest.FixtureRequest) -> Generator[None, None, None]:
     """Disable network access for tests unless marked as integration."""
     if "integration" not in request.keywords:
-        disable_socket()
+        disable_socket(allow_unix_socket=True)
         yield
         enable_socket()
     else:


### PR DESCRIPTION
## Summary
- allow unix domain sockets when blocking network access in tests
- accept JSON body in `/query` endpoint via `QueryRequest`

## Testing
- `./check.sh`