### PR TITLE
Implement RAG engine endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,6 @@
 
 ---
 
-- Create server module `src/rag/mcp_server.py` with a FastAPI app exposing the endpoints.
-- Wire existing RAG engine into `/query`, `/search`, and `/chat` endpoints.
 - Implement document management functions for listing, metadata retrieval, and deletion.
 - Add index management endpoints to index paths and rebuild or inspect the index.
 - Expose cache and system tools for clearing caches and checking server status.

--- a/src/rag/mcp_server.py
+++ b/src/rag/mcp_server.py
@@ -7,86 +7,109 @@ be wired into the RAG engine later.
 
 from __future__ import annotations
 
+import logging
+from functools import lru_cache
 from typing import Any
 
 from fastapi import FastAPI
+from pydantic import BaseModel
 
-app = FastAPI(title="RAG MCP Server")
+from rag import RAGConfig, RAGEngine, RuntimeOptions
 
-
-@app.post("/query")
-async def query_endpoint(
-    question: str,
-    top_k: int | None = None,
-    filters: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Handle RAG query requests."""
-    return {"detail": "Not implemented"}
+logger = logging.getLogger(__name__)
 
 
-@app.post("/search")
-async def search_endpoint(
-    question: str,
-    top_k: int | None = None,
-    filters: dict[str, Any] | None = None,
-) -> dict[str, Any]:
-    """Handle semantic search requests."""
-    return {"detail": "Not implemented"}
+class QueryPayload(BaseModel):
+    question: str
+    top_k: int = 4
+    filters: dict[str, Any] | None = None
 
 
-@app.post("/chat")
-async def chat_endpoint(
-    session_id: str,
-    message: str,
-    history: list[str] | None = None,
-) -> dict[str, Any]:
-    """Continue a chat session."""
-    return {"detail": "Not implemented"}
+class ChatPayload(BaseModel):
+    session_id: str
+    message: str
+    history: list[str] | None = None
 
 
-@app.get("/documents")
-async def list_documents() -> list[str]:
-    """List indexed documents."""
-    return []
+@lru_cache(maxsize=1)
+def _default_engine() -> RAGEngine:
+    """Return a cached :class:`RAGEngine` instance."""
+
+    return RAGEngine(RAGConfig(documents_dir="docs"), RuntimeOptions())
 
 
-@app.get("/documents/{doc_id}")
-async def get_document_metadata(doc_id: str) -> dict[str, Any]:
-    """Retrieve metadata for a document."""
-    return {"doc_id": doc_id}
+def create_app(engine: RAGEngine | None = None) -> FastAPI:
+    """Create the FastAPI MCP server application."""
 
+    engine = engine or _default_engine()
+    app = FastAPI(title="RAG MCP Server")
 
-@app.delete("/documents/{doc_id}")
-async def remove_document(doc_id: str) -> dict[str, str]:
-    """Remove a document from the corpus."""
-    return {"detail": f"Document {doc_id} removed"}
+    @app.post("/query")
+    async def query_endpoint(payload: QueryPayload) -> dict[str, Any]:
+        """Run a RAG query against the indexed corpus."""
 
+        return engine.answer(payload.question, k=payload.top_k)
 
-@app.post("/index")
-async def index_path(path: str) -> dict[str, str]:
-    """Index a file or folder."""
-    return {"detail": f"Indexing {path} not implemented"}
+    @app.post("/search")
+    async def search_endpoint(payload: QueryPayload) -> dict[str, Any]:
+        """Return documents most relevant to *question*."""
 
+        result = engine.answer(payload.question, k=payload.top_k)
+        return {"documents": result.get("sources", [])}
 
-@app.post("/index/rebuild")
-async def rebuild_index() -> dict[str, str]:
-    """Rebuild the entire index."""
-    return {"detail": "Rebuild index not implemented"}
+    @app.post("/chat")
+    async def chat_endpoint(payload: ChatPayload) -> dict[str, Any]:
+        """Respond to *message* within a chat session."""
 
+        result = engine.answer(payload.message, k=4)
+        return {"session_id": payload.session_id, "answer": result["answer"]}
 
-@app.get("/index/stats")
-async def get_index_stats() -> dict[str, Any]:
-    """Retrieve index statistics."""
-    return {}
+    @app.get("/documents")
+    async def list_documents() -> list[str]:
+        """List indexed documents."""
 
+        return []
 
-@app.post("/cache/clear")
-async def clear_cache() -> dict[str, str]:
-    """Clear embedding and search caches."""
-    return {"detail": "Cache cleared"}
+    @app.get("/documents/{doc_id}")
+    async def get_document_metadata(doc_id: str) -> dict[str, Any]:
+        """Retrieve metadata for a document."""
 
+        return {"doc_id": doc_id}
 
-@app.get("/system/status")
-async def system_status() -> dict[str, str]:
-    """Return server status summary."""
-    return {"status": "ok"}
+    @app.delete("/documents/{doc_id}")
+    async def remove_document(doc_id: str) -> dict[str, str]:
+        """Remove a document from the corpus."""
+
+        return {"detail": f"Document {doc_id} removed"}
+
+    @app.post("/index")
+    async def index_path(path: str) -> dict[str, str]:
+        """Index a file or folder."""
+
+        return {"detail": f"Indexing {path} not implemented"}
+
+    @app.post("/index/rebuild")
+    async def rebuild_index() -> dict[str, str]:
+        """Rebuild the entire index."""
+
+        return {"detail": "Rebuild index not implemented"}
+
+    @app.get("/index/stats")
+    async def get_index_stats() -> dict[str, Any]:
+        """Retrieve index statistics."""
+
+        return {}
+
+    @app.post("/cache/clear")
+    async def clear_cache() -> dict[str, str]:
+        """Clear embedding and search caches."""
+
+        return {"detail": "Cache cleared"}
+
+    @app.get("/system/status")
+    async def system_status() -> dict[str, str]:
+        """Return server status summary."""
+
+        return {"status": "ok"}
+
+    return app

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,20 +1,22 @@
 import pytest
+from fastapi.testclient import TestClient
 
 fastapi = pytest.importorskip("fastapi")
-from fastapi.testclient import TestClient
-from rag.mcp_server import app
-
-client = TestClient(app)
 
 
-def test_query_endpoint() -> None:
-    response = client.post("/query", json={"question": "hi"})
+def test_query_endpoint(mcp_client: TestClient, socket_enabled) -> None:
+    """Query endpoint uses the injected engine."""
+
+    response = mcp_client.post("/query", json={"question": "hi"})
     assert response.status_code == 200
     data = response.json()
-    assert data["detail"] == "Not implemented"
+    assert data["question"] == "hi"
+    assert "answer" in data
 
 
-def test_system_status_endpoint() -> None:
-    response = client.get("/system/status")
+def test_system_status_endpoint(mcp_client: TestClient, socket_enabled) -> None:
+    """System status endpoint returns OK."""
+
+    response = mcp_client.get("/system/status")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- make RAG engine injectable via `create_app`
- provide dummy engine fixture for testing
- update MCP server tests to use injected engine
- tidy completed TODO task

## Testing
- `./check.sh`