### PR TITLE
Implement MCP document management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded MCP server design sketch with third-party library recommendations
 - Skeleton FastAPI MCP server module exposing placeholder endpoints
 - Basic endpoint tests for the MCP server using FastAPI's TestClient
+- Implemented document listing, metadata retrieval and deletion endpoints
 
 ### Changed
 - Log levels are now shown in uppercase for better readability

--- a/TODO.md
+++ b/TODO.md
@@ -3,8 +3,6 @@
 ---
 
 ### MCP Server Integration
-
-- **[ID-002]** Implement document management functions for listing, metadata retrieval, and deletion.
 - **[ID-003]** Add index management endpoints to index paths and rebuild or inspect the index.
 - **[ID-004]** Expose cache and system tools for clearing caches and checking server status.
 - **[ID-005]** Provide API key authentication middleware with a configurable key.

--- a/tests/unit/test_cache_logic.py
+++ b/tests/unit/test_cache_logic.py
@@ -43,12 +43,17 @@ class TestCacheLogic:
         )
         runtime_options = RuntimeOptions()
         
-        with patch('rag.embeddings.embedding_provider.EmbeddingProvider') as mock_embed_provider:
+        with patch('rag.engine.EmbeddingProvider') as mock_embed_provider, \
+             patch('rag.embeddings.embedding_provider.EmbeddingProvider'), \
+             patch('rag.engine.ChatOpenAI'):
             # Mock embedding provider
             mock_embeddings = MagicMock()
             mock_embeddings.embed_documents.return_value = [[0.1, 0.2, 0.3]] * 2  # Mock embeddings
             mock_embed_provider.return_value.embeddings = mock_embeddings
-            
+            mock_embed_provider.return_value.get_model_info.return_value = {
+                "model_version": "test"
+            }
+
             engine = RAGEngine(config, runtime_options)
             return engine
 

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,10 +1,14 @@
 import os
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
 os.environ["RAG_MCP_DUMMY"] = "1"
 from fastapi.testclient import TestClient
-from rag.mcp_server import app
+from rag.mcp_server import app, _compute_doc_id
 
 client = TestClient(app)
 
@@ -21,3 +25,72 @@ def test_system_status_endpoint(socket_enabled) -> None:
     response = client.get("/system/status")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+class _StubIndexMeta:
+    def __init__(self, meta: dict[str, dict[str, Any]]) -> None:
+        self._meta = meta
+
+    def get_metadata(self, file_path: Path) -> dict[str, Any] | None:
+        return self._meta.get(str(file_path))
+
+
+class _StubEngine:
+    def __init__(self, info: list[dict[str, Any]], meta: dict[str, dict[str, Any]]) -> None:
+        self._info = info
+        self.index_meta = _StubIndexMeta(meta)
+        self.invalidated: Path | None = None
+
+    def list_indexed_files(self) -> list[dict[str, Any]]:
+        return self._info
+
+    def invalidate_cache(self, file_path: str) -> None:
+        self.invalidated = Path(file_path)
+
+
+@patch("rag.mcp_server.get_engine")
+def test_document_endpoints(mock_get_engine: MagicMock, socket_enabled) -> None:
+    info = [
+        {
+            "file_path": "/tmp/doc.txt",
+            "file_type": "text/plain",
+            "num_chunks": 1,
+            "file_size": 12,
+            "embedding_model": "model",
+            "embedding_model_version": "v1",
+            "indexed_at": 1.0,
+            "last_modified": 1.0,
+        }
+    ]
+    meta = {
+        "/tmp/doc.txt": {
+            "file_hash": "hash",
+            "chunk_size": 1000,
+            "chunk_overlap": 200,
+            "last_modified": 1.0,
+            "indexed_at": 1.0,
+            "embedding_model": "model",
+            "embedding_model_version": "v1",
+            "file_type": "text/plain",
+            "num_chunks": 1,
+            "file_size": 12,
+        }
+    }
+    engine = _StubEngine(info, meta)
+    mock_get_engine.return_value = engine
+
+    doc_id = _compute_doc_id("/tmp/doc.txt")
+
+    response = client.get("/documents")
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["doc_id"] == doc_id
+
+    response = client.get(f"/documents/{doc_id}")
+    assert response.status_code == 200
+    detail = response.json()
+    assert detail["file_path"] == "/tmp/doc.txt"
+
+    response = client.delete(f"/documents/{doc_id}")
+    assert response.status_code == 200
+    assert engine.invalidated == Path("/tmp/doc.txt")


### PR DESCRIPTION
## Summary
- support listing, metadata retrieval and deletion of documents via FastAPI
- remove completed ID-002 task from TODO
- update changelog
- add tests for document endpoints
- patch OpenAI usage in cache logic tests

## Testing
- `OPENAI_API_KEY=sk-test ./check.sh` *(fails: File should NOT be processed when already cached and unchanged)*