### PR TITLE
Align contributor docs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -56,6 +56,9 @@
 8. When the task is complete, run check.sh to ensure no errors or linting problems
 9. Run integration tests to verify end-to-end functionality
 10. Remove completed tasks from TODO.md and update CHANGELOG.md with the changes
+11. Update documentation to reflect your changes before marking the task complete
+12. Keep `.cursorrules`, `AGENTS.md`, and `CONTRIBUTING.md` in sync; update all
+    three when modifying contributor guidelines
 
 # Coding Guidelines
 
@@ -95,6 +98,7 @@
 ## 5. Testing
 
 - **Unit Tests**: Write unit tests using `pytest` for individual components.
+- **Write Tests for Changes**: Add tests for all code changes whenever feasible, especially when fixing bugs or regressions.
 - **Integration Tests**: Include a small number of integration tests focused on common end-user use cases.
 - **Test Coverage**: Aim for high test coverage of business logic, but don't test third-party code.
 - **Test Speed**: Keep tests focused and fast; individual unit tests should take less than 0.5 seconds.
@@ -127,6 +131,7 @@
 # Code Requirements
 
 - **Type Annotations**: All functions must include type annotations.
+- **Pydantic Models**: Use Pydantic models for all API request and response schemas.
 - **Docstrings**: Use Google-style docstrings for all public APIs.
 - **Comments**: Annotate key logic with comments.
 - **Examples**: Provide usage examples in docstrings or tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,10 @@ This repository welcomes contributions from AI-based tools. When acting as an ag
 2. **Run `./check.sh`** after making changes. This script formats the code, lints it and runs the unit tests.
 3. **Keep commits atomic** and use the conventional commit style described in `.cursorrules`.
 4. **Do not introduce external dependencies** without updating `pyproject.toml`.
-5. **Never commit secrets or generated files.**
+5. **Write tests for your changes** whenever feasible, especially for bug or regression fixes.
+6. **Use Pydantic models** for all API request and response data.
+7. **Update documentation** before completing a task.
+8. **Never commit secrets or generated files.**
+9. **Keep contributor docs aligned** – update `.cursorrules`, `AGENTS.md`, and `CONTRIBUTING.md` together when guidelines change.
 
 For human contributors, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,13 @@ Unit tests run with network access disabled using `pytest-socket`. If a test
 needs network access, mark it with `@pytest.mark.integration` and run it via
 `tests/run_integration_tests.py`.
 
+## Development Guidelines
+
+- Write tests for all code changes whenever feasible, especially when fixing bugs or regressions.
+- Use Pydantic models for all API request and response schemas.
+- Update documentation alongside code changes.
+- Keep `.cursorrules`, `AGENTS.md`, and `CONTRIBUTING.md` synchronized when guidelines change.
+
 ## Git Workflow
 
 - Use feature branches for your work and keep them short-lived.

--- a/README.md
+++ b/README.md
@@ -377,23 +377,8 @@ Each command produces structured JSON output:
  }
   ```
 
-## Running Tests
-
-Execute `./check.sh` to format, lint, and run the unit tests. Network access is
-disabled by default using `pytest-socket`. Tests that require the network should
-be marked with `@pytest.mark.integration` and run with
-`tests/run_integration_tests.py`.
-
-## GitHub Integration Tests
-
-Integration tests can be run in GitHub Actions. The workflow is triggered
-manually and requires two repository secrets:
-
-1. `OPENAI_API_KEY` – your OpenAI API key used by the tests.
-2. `INTEGRATION_ACTOR` – the GitHub username allowed to run the workflow.
-
-Head to **Actions → Integration Tests** and choose **Run workflow** to start a
-test run.
+For development and testing instructions, see
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Summary
- document how to keep `.cursorrules`, `AGENTS.md` and `CONTRIBUTING.md` in sync
- add rules for pydantic models and documentation updates
- mention writing tests for all changes
- move testing instructions out of README

## Testing
- `./check.sh`