### PR TITLE
Add API key middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic endpoint tests for the MCP server using FastAPI's TestClient
 - Implemented document listing, metadata retrieval and deletion endpoints
 - Added index management endpoints (`/index`, `/index/rebuild`, `/index/stats`) in the MCP server
+- API key authentication middleware for the MCP server via `RAG_MCP_API_KEY`
 
 ### Changed
 - Log levels are now shown in uppercase for better readability

--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ Invalidate all caches in a directory:
 rag invalidate --all path/to/directory
 ```
 
+### MCP Server
+
+The project includes a lightweight FastAPI server. Set `RAG_MCP_API_KEY` to
+enable API key authentication. When enabled, each request must include an
+`X-API-Key` header matching the configured value.
+
 ### Getting Help
 
 Show general help:

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 
 ### MCP Server Integration
 - **[ID-004]** Expose cache and system tools for clearing caches and checking server status.
-- **[ID-005]** Provide API key authentication middleware with a configurable key.
 - **[ID-006]** Integrate CLI command `rag serve-mcp` to start the server with host and port options.
 - **[ID-007]** Write unit tests covering each endpoint and authentication logic.
 - **[ID-008]** Add integration test that starts the server and performs a sample query.

--- a/docs/design_sketches/mcp_server_integration.md
+++ b/docs/design_sketches/mcp_server_integration.md
@@ -58,7 +58,7 @@ ergonomics, ensuring the server can be implemented and tested efficiently.
 3. **Implement document management** functions for listing, metadata retrieval, and deletion.
 4. **Add index management** endpoints to index paths and rebuild or inspect the index. ✅ Implemented.
 5. **Expose cache and system tools** for clearing caches and checking server status.
-6. **Provide API key authentication** middleware with a configurable key.
+6. **Provide API key authentication** middleware with a configurable key. ✅ Implemented via `RAG_MCP_API_KEY`.
 7. **Integrate CLI command** `rag serve-mcp` to start the server with host and port options.
 8. **Write unit tests** covering each endpoint and authentication logic.
 9. **Add integration test** that starts the server and performs a sample query.


### PR DESCRIPTION
## Summary
- add configurable API key middleware to MCP server
- test authentication logic
- document RAG_MCP_API_KEY usage
- remove completed TODO item
- note middleware in changelog

## Testing
- `./check.sh`