### PR TITLE
Add OPENAI_API_KEY validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Step-by-step MCP usage guide for ChatGPT and Cursor in `docs/mcp_usage.md`.
 - Tailscale instructions for remote ChatGPT access added to the MCP usage guide.
 - Added `serve-mcp` CLI command for running the MCP server
+- Validation check for `OPENAI_API_KEY` during engine initialization
 
 ### Removed
 - Outdated design sketch removed from `docs/design_sketches`.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ pip install rag
    RAG_SYSTEM_PROMPT="You are a helpful assistant."
    ```
 
+   The engine validates that `OPENAI_API_KEY` is set and exits with an
+   error if it is missing.
+
 2. The tool will automatically look for the `.env` file in:
    - Current directory
    - Parent directories (up to 3 levels up)

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 - [#153] [P1] **Increase coverage for utils** – Add tests for `answer_utils` and `async_utils`.
 - [#154] [P1] **Prompt list command** – Add CLI subcommand to list available prompt templates.
 - [#155] [P1] **Refactor MCP utilities** – Consolidate duplicated server logic.
-- [#156] [P1] **Validate OPENAI_API_KEY** – Fail fast if API key is missing.
 ---
 
 ## 🗺️ Roadmap & Priorities
@@ -17,7 +16,6 @@
 - [#44] [P2] **Vector-store abstraction** – Introduce `VectorStoreProtocol` so FAISS can be swapped for Qdrant/Chroma via a CLI flag.
 - [#45] [P3] **Incremental re-indexing** – Hash each chunk and only (re)embed changed chunks to reduce token spend.
 - [P2] **Refactor MCP utilities** – Consolidate duplicated server logic.
-- [P2] **Validate OPENAI_API_KEY** – Fail fast if API key is missing.
 
 ### 2 . Retrieval & Relevance
 - [#47] [P2] **Hybrid retrieval** – Combine BM25 (sparse) + dense scores via reciprocal rank fusion.

--- a/src/rag/engine.py
+++ b/src/rag/engine.py
@@ -86,6 +86,9 @@ class RAGEngine:
         ):
             self.runtime.progress_callback = None
 
+        # Fail fast if the API key is missing
+        self._validate_api_key()
+
         # Initialize components
         self._initialize_from_config()
 
@@ -140,6 +143,14 @@ class RAGEngine:
 
         """
         log_message(level, message, subsystem, self.runtime.log_callback)
+
+    def _validate_api_key(self) -> None:
+        """Ensure the OpenAI API key is configured."""
+
+        if not self.config.openai_api_key:
+            raise ValueError(
+                "OpenAI API key is missing. Set the OPENAI_API_KEY environment variable."
+            )
 
     def _create_default_config(self) -> RAGConfig:
         """Create default configuration.

--- a/tests/unit/test_cache_logic.py
+++ b/tests/unit/test_cache_logic.py
@@ -40,6 +40,7 @@ class TestCacheLogic:
             chunk_size=100,
             chunk_overlap=20,
             embedding_model="text-embedding-3-small",
+            openai_api_key="test-key",
         )
         runtime_options = RuntimeOptions()
         

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -5,6 +5,7 @@ Focus on testing our core business logic, not mock interfaces.
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+import os
 
 from rag.config import RAGConfig, RuntimeOptions
 from rag.engine import RAGEngine
@@ -90,6 +91,7 @@ def test_engine_backward_compatibility(_mock_initialize: MagicMock) -> None:
         assert engine.config.openai_api_key == "test-key"
 
 
+@patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True)
 @patch.object(RAGEngine, "_initialize_from_config", autospec=True)
 def test_create_default_config(_mock_initialize: MagicMock) -> None:
     """Test creating default configuration.
@@ -100,7 +102,6 @@ def test_create_default_config(_mock_initialize: MagicMock) -> None:
     """
     # Mock the index_manager attribute to avoid AttributeError
     with patch.object(RAGEngine, "index_manager", create=True, new=MagicMock()):
-        # Create engine with initialization mocked
         engine = RAGEngine()
 
         # Get default config
@@ -126,7 +127,11 @@ def test_initialize_paths(_mock_mkdir: MagicMock) -> None:
 
     """
     # Create config with test directories
-    config = RAGConfig(documents_dir="test_documents", cache_dir="test_cache")
+    config = RAGConfig(
+        documents_dir="test_documents",
+        cache_dir="test_cache",
+        openai_api_key="test-key",
+    )
 
     # Create engine with full initialization mocked
     with (
@@ -152,6 +157,7 @@ def test_initialize_paths(_mock_mkdir: MagicMock) -> None:
         _mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)
 
 
+@patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True)
 @patch.object(RAGEngine, "_initialize_from_config", autospec=True)
 def test_load_cached_vectorstore_none(_mock_initialize: MagicMock) -> None:
     """Return ``None`` when no cached vectorstore is found."""


### PR DESCRIPTION
## Summary
- validate that OPENAI_API_KEY is provided when the engine starts
- document validation behaviour in README
- remove TODO for API key validation
- note the new check in CHANGELOG
- update unit tests to supply a mock API key

## Testing
- `./check.sh`