### PR TITLE
Implement incremental re-indexing

### DIFF
--- a/src/rag/engine.py
+++ b/src/rag/engine.py
@@ -454,21 +454,7 @@ class RAGEngine:
             True if successful, False otherwise
         """
         try:
-            # Get embeddings
-            self._log(
-                "DEBUG",
-                f"Generating embeddings for {len(documents)} documents from {file_path}",
-            )
-            embeddings = self.embedding_batcher.process_embeddings(documents)
-            self._log("DEBUG", f"Generated {len(embeddings)} embeddings")
-
-            # Debug: Check first embedding
-            if embeddings:
-                first_emb = embeddings[0]
-                emb_shape = f"length={len(first_emb)}, type={type(first_emb)}"
-                self._log("DEBUG", f"First embedding shape: {emb_shape}")
-
-            # Get existing vectorstore if available
+            # Load existing vectorstore if available
             existing_vectorstore = self.vectorstores.get(str(file_path))
             if not existing_vectorstore:
                 self._log(
@@ -480,20 +466,56 @@ class RAGEngine:
                 )
                 if existing_vectorstore:
                     self._log("DEBUG", "Loaded existing vectorstore from cache")
-                else:
-                    self._log("DEBUG", "No existing vectorstore found in cache")
 
-            # Create or update vectorstore
-            self._log("DEBUG", "Adding documents to vectorstore")
-            vectorstore = self.vectorstore_manager.add_documents_to_vectorstore(
-                vectorstore=existing_vectorstore,
-                documents=documents,
-                embeddings=embeddings,
-            )
-            self._log(
-                "DEBUG",
-                f"Added documents to vectorstore, store type: {type(vectorstore)}",
-            )
+            old_hashes = self.index_manager.get_chunk_hashes(file_path)
+            new_hashes: list[str] = []
+
+            # Create a new vectorstore and process chunks sequentially
+            vectorstore = self.vectorstore_manager.create_empty_vectorstore()
+
+            docs_to_embed: list[Document] = []
+            embed_indices: list[int] = []
+
+            for idx, doc in enumerate(documents):
+                chunk_hash = self.index_manager.compute_text_hash(doc.page_content)
+                new_hashes.append(chunk_hash)
+
+                if (
+                    existing_vectorstore
+                    and idx < len(old_hashes)
+                    and chunk_hash == old_hashes[idx]
+                ):
+                    try:
+                        emb = existing_vectorstore.index.reconstruct(idx)
+                        self.vectorstore_manager.add_documents_to_vectorstore(
+                            vectorstore,
+                            [doc],
+                            [emb],
+                        )
+                        continue
+                    except Exception:
+                        pass
+
+                docs_to_embed.append(doc)
+                embed_indices.append(idx)
+
+            if docs_to_embed:
+                self._log(
+                    "DEBUG",
+                    f"Generating embeddings for {len(docs_to_embed)} new/changed documents",
+                )
+                embeddings = self.embedding_batcher.process_embeddings(docs_to_embed)
+                self._log("DEBUG", f"Generated {len(embeddings)} embeddings")
+
+                for pos, idx in enumerate(embed_indices):
+                    if pos >= len(embeddings):
+                        break
+                    doc = documents[idx]
+                    self.vectorstore_manager.add_documents_to_vectorstore(
+                        vectorstore,
+                        [doc],
+                        [embeddings[pos]],
+                    )
 
             # Save vectorstore
             self._log("DEBUG", "Saving vectorstore to cache")
@@ -513,6 +535,9 @@ class RAGEngine:
                 file_type=file_type,
                 num_chunks=len(documents),
             )
+
+            # Store chunk hashes for incremental indexing
+            self.index_manager.update_chunk_hashes(file_path, new_hashes)
 
             # Update cache metadata
             self._log("DEBUG", "Getting file metadata")


### PR DESCRIPTION
## Summary
- store per-chunk hashes in IndexManager
- compute chunk hashes and reuse embeddings during indexing
- add tests for new IndexManager helpers

## Testing
- `./check.sh`