### PR TITLE
Implement REPL autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `summarize`: Table of document summaries
     - `cleanup`: Summary of removed files
     - `invalidate`: Success/error messages
+- Autocomplete support in `rag repl` using `prompt_toolkit` for commands and file paths
+- Documented REPL autocomplete usage in README
 - Structured logging using structlog with Rich console output
   - Consistent error output format across all commands
   - Integration with tools like `jq` for output processing

--- a/README.md
+++ b/README.md
@@ -117,12 +117,20 @@ The REPL provides:
 - Command history (up/down arrows)
 - Auto-suggestions from history
 - Syntax highlighting
-- Auto-completion
+- Auto-completion for commands and file paths
 - Built-in commands:
   - `clear` - Clear the screen
   - `exit` or `quit` - Exit the REPL
   - `help` - Show help message
   - `k <number>` - Change number of documents to retrieve
+
+#### Auto-completion
+
+The REPL uses `prompt_toolkit`'s completer system to provide both command and
+file path completion. Press <kbd>TAB</kbd> to cycle through available commands or
+to expand file and directory paths. Paths support `~` for your home directory and
+work with relative or absolute locations. This makes it easy to reference files
+when interacting with the REPL.
 
 ### Indexing Documents
 

--- a/TODO.md
+++ b/TODO.md
@@ -26,7 +26,6 @@
 
 ### 5 . CLI / REPL UX
 - [#55] [P2] **Streaming token output** – `--stream` flag for real-time coloured output.
-- [#56] [P3] **Autocomplete in `rag repl`** – Use `prompt_toolkit` for file path & command completion.
 
 ### 6 . Performance
 - [#57] [P2] **Async embedding workers** – `asyncio` + `aiostream` pipeline instead of ThreadPool; honour OpenAI parallel limits.

--- a/src/rag/cli/cli.py
+++ b/src/rag/cli/cli.py
@@ -17,7 +17,11 @@ import typer
 from dotenv import load_dotenv
 from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
-from prompt_toolkit.completion import WordCompleter
+from prompt_toolkit.completion import (
+    PathCompleter,
+    WordCompleter,
+    merge_completers,
+)
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.styles import Style
@@ -894,6 +898,16 @@ def _get_repl_commands() -> dict[str, Any]:
     }
 
 
+def _get_repl_completer(commands: dict[str, Any]):
+    """Return a completer for the REPL with command and path completion."""
+    return merge_completers(
+        [
+            WordCompleter(commands.keys()),
+            PathCompleter(expanduser=True),
+        ]
+    )
+
+
 def print_welcome_message() -> None:
     """Print welcome message for the CLI."""
     state.console.print(
@@ -964,7 +978,7 @@ def repl(
         session = _create_repl_session()
         style = _get_repl_style()
         commands = _get_repl_commands()
-        command_completer = WordCompleter(commands.keys())
+        command_completer = _get_repl_completer(commands)
 
         # Print welcome message
         print_welcome_message()

--- a/tests/unit/cli/test_repl.py
+++ b/tests/unit/cli/test_repl.py
@@ -1,0 +1,15 @@
+import types
+
+from prompt_toolkit.completion import PathCompleter, WordCompleter
+
+from rag.cli.cli import _get_repl_completer
+
+
+def test_get_repl_completer_returns_merged():
+    commands = {"exit": lambda: None, "clear": lambda: None}
+    completer = _get_repl_completer(commands)
+    # _MergedCompleter is not exported, so compare attributes
+    assert hasattr(completer, "completers")
+    sub_types = {type(c) for c in completer.completers}
+    assert WordCompleter in sub_types
+    assert PathCompleter in sub_types


### PR DESCRIPTION
## Summary
- allow path completion in rag repl and expose helper
- test new completer
- update docs and changelog
- remove completed task from TODO
- document REPL autocomplete usage

## Testing
- `./check.sh`
