### PR TITLE
Implement vector store backend protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ rag index path/to/documents --no-preserve-headings
 
 # Combine options as needed
 rag index path/to/documents --chunk-size 2000 --no-preserve-headings
+# Use a different vector store backend
+rag index path/to/documents --vectorstore-backend faiss
 ```
 
 This will:

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,6 @@
 
 
 ### 1 . Architecture & Core Design
-- [#44] [P2] **Vector-store abstraction** – Introduce `VectorStoreProtocol` so FAISS can be swapped for Qdrant/Chroma via a CLI flag.
 - [#45] [P3] **Incremental re-indexing** – Hash each chunk and only (re)embed changed chunks to reduce token spend.
 - [P2] **Refactor MCP utilities** – Consolidate duplicated server logic.
 

--- a/src/rag/chains/rag_chain.py
+++ b/src/rag/chains/rag_chain.py
@@ -20,13 +20,13 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
-from langchain_community.vectorstores import FAISS  # type: ignore
 from langchain_core.documents import Document
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableLambda, RunnableParallel
 
 # Import the prompt registry
 from rag.prompts import get_prompt
+from rag.storage.protocols import VectorStoreProtocol
 from rag.utils.exceptions import VectorstoreError
 
 # Forward reference for type checking
@@ -120,7 +120,7 @@ def build_rag_chain(engine: RAGEngine, k: int = 4, prompt_id: str = "default"):
     if not engine.vectorstores:
         raise VectorstoreError()
 
-    merged_vs: FAISS = engine.vectorstore_manager.merge_vectorstores(  # type: ignore[arg-type]
+    merged_vs: VectorStoreProtocol = engine.vectorstore_manager.merge_vectorstores(  # type: ignore[arg-type]
         list(engine.vectorstores.values())
     )
 

--- a/src/rag/cli/cli.py
+++ b/src/rag/cli/cli.py
@@ -85,6 +85,7 @@ class GlobalState:
     cache_dir: str = CACHE_DIR  # Initialize with default value
     json_mode: bool = False  # Track JSON mode
     console: Console = console  # Store console instance
+    vectorstore_backend: str = "faiss"
 
 
 state = GlobalState()
@@ -101,6 +102,12 @@ JSON_OUTPUT_OPTION = typer.Option(
     None,
     "--json/--no-json",
     help="Output in JSON format",
+)
+
+VECTORSTORE_OPTION = typer.Option(
+    "faiss",
+    "--vectorstore-backend",
+    help="Vector store backend (faiss, qdrant, chroma)",
 )
 
 # Define argument defaults outside functions
@@ -168,6 +175,7 @@ def main(
         "-c",
         help="Directory for caching embeddings and vector stores",
     ),
+    vectorstore_backend: str = VECTORSTORE_OPTION,
     json_output: bool = JSON_OUTPUT_OPTION,
 ) -> None:
     """RAG (Retrieval Augmented Generation) CLI.
@@ -188,6 +196,7 @@ def main(
 
     # Set cache directory
     state.cache_dir = cache_dir
+    state.vectorstore_backend = vectorstore_backend
 
     # Set up signal handlers
     signal.signal(signal.SIGINT, signal_handler)
@@ -269,6 +278,7 @@ def index(  # noqa: PLR0913
             chunk_size=chunk_size,
             chunk_overlap=chunk_overlap,
             cache_dir=cache_dir or state.cache_dir,
+            vectorstore_backend=state.vectorstore_backend,
         )
         runtime_options = RuntimeOptions(
             preserve_headings=preserve_headings,
@@ -418,6 +428,7 @@ def invalidate(
             chat_model="gpt-4",
             temperature=0.0,
             cache_dir=cache_directory,
+            vectorstore_backend=state.vectorstore_backend,
         )
         runtime_options = RuntimeOptions()
         rag_engine = RAGEngine(config, runtime_options)
@@ -508,6 +519,7 @@ def query(
             chat_model="gpt-4",
             temperature=0.0,
             cache_dir=cache_directory,
+            vectorstore_backend=state.vectorstore_backend,
         )
         runtime_options = RuntimeOptions()
         rag_engine = RAGEngine(config, runtime_options)
@@ -615,6 +627,7 @@ def summarize(
             chat_model="gpt-4",
             temperature=0.0,
             cache_dir=cache_dir or state.cache_dir,
+            vectorstore_backend=state.vectorstore_backend,
         )
         runtime_options = RuntimeOptions()
         rag_engine = RAGEngine(config, runtime_options)
@@ -723,6 +736,7 @@ def list(
             chat_model="gpt-4",
             temperature=0.0,
             cache_dir=cache_directory,
+            vectorstore_backend=state.vectorstore_backend,
         )
         runtime_options = RuntimeOptions()
         rag_engine = RAGEngine(config, runtime_options)
@@ -802,6 +816,7 @@ def _initialize_rag_engine() -> RAGEngine:
         chat_model="gpt-4",
         temperature=0.0,
         cache_dir=state.cache_dir,
+        vectorstore_backend=state.vectorstore_backend,
     )
     runtime_options = RuntimeOptions()
     return RAGEngine(config, runtime_options)
@@ -1069,6 +1084,7 @@ def cleanup(
         config = RAGConfig(
             documents_dir=".",  # Not used for cleanup, but required
             cache_dir=cache_dir or state.cache_dir,
+            vectorstore_backend=state.vectorstore_backend,
         )
 
         # Initialize the RAG engine

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -26,6 +26,7 @@ class RAGConfig:
         chunk_size: Number of tokens per chunk
         chunk_overlap: Number of tokens to overlap between chunks
         openai_api_key: OpenAI API key (will be set in __post_init__)
+        vectorstore_backend: Backend to use for vector storage
 
     """
 
@@ -38,6 +39,7 @@ class RAGConfig:
     chunk_size: int = 1000  # tokens
     chunk_overlap: int = 200  # tokens
     openai_api_key: str = ""  # Will be set in __post_init__
+    vectorstore_backend: str = "faiss"
 
     def __post_init__(self):
         """Initialize derived attributes after instance creation."""

--- a/src/rag/engine.py
+++ b/src/rag/engine.py
@@ -10,7 +10,6 @@ import os
 from pathlib import Path
 from typing import Any
 
-from langchain_community.vectorstores import FAISS
 from langchain_core.documents import Document
 
 # Update LangChain imports to use community packages
@@ -30,6 +29,7 @@ from .ingest import BasicPreprocessor, IngestManager
 from .storage.cache_manager import CacheManager
 from .storage.filesystem import FilesystemManager
 from .storage.index_manager import IndexManager
+from .storage.protocols import VectorStoreProtocol
 from .storage.vectorstore import VectorStoreManager
 from .utils.logging_utils import log_message
 
@@ -169,6 +169,7 @@ class RAGEngine:
             chunk_size=1000,
             chunk_overlap=200,
             openai_api_key=os.getenv("OPENAI_API_KEY", ""),
+            vectorstore_backend="faiss",
         )
 
     def _initialize_from_config(self) -> None:
@@ -234,6 +235,7 @@ class RAGEngine:
             log_callback=self.runtime.log_callback,
             lock_timeout=self.config.lock_timeout,
             safe_deserialization=False,  # We trust our own cache files
+            backend=self.config.vectorstore_backend,
         )
 
     def _initialize_embeddings(self) -> None:
@@ -915,14 +917,14 @@ class RAGEngine:
         """
         return self._load_cache_metadata()
 
-    def load_cached_vectorstore(self, file_path: str) -> FAISS | None:
+    def load_cached_vectorstore(self, file_path: str) -> VectorStoreProtocol | None:
         """Load a cached vectorstore.
 
         Args:
             file_path: Path to the source file
 
         Returns:
-            Loaded FAISS vectorstore or ``None`` if not found
+            Loaded vector store or ``None`` if not found
 
         """
         return self._load_cached_vectorstore(file_path)
@@ -936,14 +938,14 @@ class RAGEngine:
         """
         return self.cache_manager.load_cache_metadata()
 
-    def _load_cached_vectorstore(self, file_path: str) -> FAISS | None:
+    def _load_cached_vectorstore(self, file_path: str) -> VectorStoreProtocol | None:
         """Backward compatibility: Load vectorstore from cache.
 
         Args:
             file_path: Path to the file
 
         Returns:
-            Loaded FAISS vectorstore or ``None`` if not found
+            Loaded vector store or ``None`` if not found
 
         """
         return self.vectorstore_manager.load_vectorstore(file_path)

--- a/src/rag/storage/protocols.py
+++ b/src/rag/storage/protocols.py
@@ -1,0 +1,21 @@
+"""Protocol definitions for storage components."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from langchain_core.documents import Document
+
+
+@runtime_checkable
+class VectorStoreProtocol(Protocol):
+    """Minimal protocol for vector store implementations."""
+
+    def as_retriever(self, *, search_type: str, search_kwargs: dict[str, Any]) -> Any:
+        """Return a retriever instance."""
+
+    def similarity_search(self, query: str, k: int = 4) -> list[Document]:
+        """Return documents similar to the query."""
+
+    def save_local(self, folder_path: str, index_name: str) -> None:
+        """Persist the vector store to disk."""


### PR DESCRIPTION
## Summary
- add `VectorStoreProtocol` and backend support to VectorStoreManager
- allow choosing backend via `--vectorstore-backend` flag
- wire backend option through RAGConfig, engine and CLI
- document backend flag and remove finished TODO entry

## Testing
- `./check.sh`