### PR TITLE
Implement per-document embedding model map

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,20 @@ The chunking behavior can be customized using CLI flags or environment variables
 - `--no-semantic-chunking`: Disables semantic chunking and uses pure token-based chunking
 - `--no-preserve-headings`: Disables document heading structure preservation
 
+#### Per-document Embedding Models
+
+You can specify different embedding models for subsets of your documents using
+an `embeddings.yaml` file placed in the documents directory. The YAML file maps
+glob patterns to model names:
+
+```yaml
+"finance/*.pdf": text-embedding-3-large
+"legal/*": text-embedding-3-small
+```
+
+Files matching a pattern will be embedded with the given model; all others use
+the default model from your configuration.
+
 ### Querying Documents
 
 Query your indexed documents using natural language:

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,6 @@
 - [#45] [P3] **Incremental re-indexing** – Hash each chunk and only (re)embed changed chunks to reduce token spend.
 
 ### 2 . Retrieval & Relevance
-- [#48] [P3] **Per-document embedding model map** – Lookup table (`embeddings.yaml`) to choose domain-specific embedding models.
 
 ### 3 . Prompt Engineering & Generation
 

--- a/embeddings.yaml
+++ b/embeddings.yaml
@@ -1,0 +1,2 @@
+# Example embedding model mapping
+"docs/*.pdf": text-embedding-3-small

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "filelock>=3.12.0",
     "mcp[cli]>=1.9.1",
     "aiostream>=0.6.4",
+    "pyyaml>=6.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/src/rag/config.py
+++ b/src/rag/config.py
@@ -27,6 +27,8 @@ class RAGConfig:
         chunk_overlap: Number of tokens to overlap between chunks
         openai_api_key: OpenAI API key (will be set in __post_init__)
         vectorstore_backend: Backend to use for vector storage
+        embedding_model_map_file: Optional path to embeddings.yaml for per-doc
+            model selection
 
     """
 
@@ -40,6 +42,7 @@ class RAGConfig:
     chunk_overlap: int = 200  # tokens
     openai_api_key: str = ""  # Will be set in __post_init__
     vectorstore_backend: str = "faiss"
+    embedding_model_map_file: str | None = None
 
     def __post_init__(self):
         """Initialize derived attributes after instance creation."""

--- a/src/rag/embeddings/model_map.py
+++ b/src/rag/embeddings/model_map.py
@@ -1,0 +1,32 @@
+"""Utilities for per-document embedding model mapping."""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+import yaml
+
+
+def load_model_map(path: str | Path) -> dict[str, str]:
+    """Load a YAML embedding model map."""
+    path = Path(path)
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError("Embedding model map must be a mapping")
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def get_model_for_path(
+    file_path: str | Path, model_map: dict[str, str], default: str
+) -> str:
+    """Return embedding model for *file_path* using *model_map*."""
+    fp = str(file_path)
+    for pattern, model in model_map.items():
+        if fnmatch.fnmatch(fp, pattern):
+            return model
+    return default

--- a/src/rag/engine.py
+++ b/src/rag/engine.py
@@ -26,6 +26,7 @@ from .data.document_processor import DocumentProcessor
 from .data.text_splitter import TextSplitterFactory
 from .embeddings.batching import EmbeddingBatcher
 from .embeddings.embedding_provider import EmbeddingProvider
+from .embeddings.model_map import get_model_for_path, load_model_map
 from .ingest import BasicPreprocessor, IngestManager
 from .storage.cache_manager import CacheManager
 from .storage.filesystem import FilesystemManager
@@ -78,6 +79,7 @@ class RAGEngine:
         # Set up configuration
         self.config = config or self._create_default_config()
         self.runtime = runtime_options or RuntimeOptions()
+        self.embedding_model_map: dict[str, str] = {}
         self.default_prompt_id: str = "default"
         self.system_prompt: str = os.getenv("RAG_SYSTEM_PROMPT", "")
 
@@ -259,9 +261,31 @@ class RAGEngine:
             progress_callback=self.runtime.progress_callback,
         )
 
+        # Load per-document embedding model map
+        self._load_embedding_model_map()
+
         self._log(
             "DEBUG",
             f"Using embedding model: {self.config.embedding_model} (version: {self.embedding_model_version})",
+        )
+
+    def _load_embedding_model_map(self) -> None:
+        """Load embedding model mapping from YAML file."""
+        map_file = self.config.embedding_model_map_file
+        if map_file is None:
+            map_file = self.documents_dir / "embeddings.yaml"
+        try:
+            self.embedding_model_map = load_model_map(map_file)
+            if self.embedding_model_map:
+                self._log("DEBUG", f"Loaded embedding model map from {map_file}")
+        except ValueError as exc:
+            self.embedding_model_map = {}
+            self._log("WARNING", f"Failed to load embedding model map: {exc}")
+
+    def _embedding_model_for_file(self, file_path: Path) -> str:
+        """Return embedding model for *file_path* based on the loaded map."""
+        return get_model_for_path(
+            file_path, self.embedding_model_map, self.config.embedding_model
         )
 
     def _initialize_document_processing(self) -> None:
@@ -374,11 +398,12 @@ class RAGEngine:
                 return False, "File does not exist"
 
             # Skip re-indexing if cached and unchanged
+            model_name = self._embedding_model_for_file(file_path)
             if not self.index_manager.needs_reindexing(
                 file_path,
                 self.config.chunk_size,
                 self.config.chunk_overlap,
-                self.config.embedding_model,
+                model_name,
                 self.embedding_model_version,
             ):
                 self._log(
@@ -430,6 +455,7 @@ class RAGEngine:
                 file_path=file_path,
                 documents=documents,
                 file_type=ingest_result.source.mime_type or "text/plain",
+                embedding_model=model_name,
             )
             return success, None
         except (
@@ -446,8 +472,12 @@ class RAGEngine:
             self._log("ERROR", f"Failed to index {file_path}: {error_message}")
             return False, error_message
 
-    def _create_vectorstore_from_documents(
-        self, file_path: Path, documents: list[Document], file_type: str
+    def _create_vectorstore_from_documents(  # noqa: PLR0915
+        self,
+        file_path: Path,
+        documents: list[Document],
+        file_type: str,
+        embedding_model: str | None = None,
     ) -> bool:
         """Create or update a vectorstore from documents.
 
@@ -478,6 +508,20 @@ class RAGEngine:
 
             # Create a new vectorstore and process chunks sequentially
             vectorstore = self.vectorstore_manager.create_empty_vectorstore()
+
+            provider = self.embedding_provider
+            batcher = self.embedding_batcher
+            if embedding_model and embedding_model != self.config.embedding_model:
+                provider = EmbeddingProvider(
+                    model_name=embedding_model,
+                    openai_api_key=self.config.openai_api_key,
+                    log_callback=self.runtime.log_callback,
+                )
+                batcher = EmbeddingBatcher(
+                    embedding_provider=provider,
+                    log_callback=self.runtime.log_callback,
+                    progress_callback=self.runtime.progress_callback,
+                )
 
             docs_to_embed: list[Document] = []
             embed_indices: list[int] = []
@@ -510,7 +554,7 @@ class RAGEngine:
                     "DEBUG",
                     f"Generating embeddings for {len(docs_to_embed)} new/changed documents",
                 )
-                embeddings = self.embedding_batcher.process_embeddings(docs_to_embed)
+                embeddings = batcher.process_embeddings(docs_to_embed)
                 self._log("DEBUG", f"Generated {len(embeddings)} embeddings")
 
                 for pos, idx in enumerate(embed_indices):
@@ -532,11 +576,12 @@ class RAGEngine:
 
             # Update metadata
             self._log("DEBUG", "Updating index metadata")
+            used_model = embedding_model or self.config.embedding_model
             self.index_manager.update_metadata(
                 file_path=file_path,
                 chunk_size=self.config.chunk_size,
                 chunk_overlap=self.config.chunk_overlap,
-                embedding_model=self.config.embedding_model,
+                embedding_model=used_model,
                 embedding_model_version=self.embedding_model_version,
                 file_type=file_type,
                 num_chunks=len(documents),
@@ -575,7 +620,7 @@ class RAGEngine:
             self._log("ERROR", f"Failed to create vectorstore for {file_path}: {e}")
             return False
 
-    def index_directory(
+    def index_directory(  # noqa: PLR0915
         self, directory: Path | str | None = None
     ) -> dict[str, dict[str, Any]]:
         """Index all files in a directory.
@@ -605,7 +650,7 @@ class RAGEngine:
                 f,
                 self.config.chunk_size,
                 self.config.chunk_overlap,
-                self.config.embedding_model,
+                self._embedding_model_for_file(f),
                 self.embedding_model_version,
             )
         ]
@@ -650,7 +695,21 @@ class RAGEngine:
                     "DEBUG",
                     f"Generating embeddings for {len(documents)} documents from {file_path}",
                 )
-                embeddings = self.embedding_batcher.process_embeddings(documents)
+                model_name = self._embedding_model_for_file(Path(file_path))
+                provider = self.embedding_provider
+                batcher = self.embedding_batcher
+                if model_name != self.config.embedding_model:
+                    provider = EmbeddingProvider(
+                        model_name=model_name,
+                        openai_api_key=self.config.openai_api_key,
+                        log_callback=self.runtime.log_callback,
+                    )
+                    batcher = EmbeddingBatcher(
+                        embedding_provider=provider,
+                        log_callback=self.runtime.log_callback,
+                        progress_callback=self.runtime.progress_callback,
+                    )
+                embeddings = batcher.process_embeddings(documents)
 
                 # Get existing vectorstore if available
                 existing_vectorstore = self.vectorstores.get(file_path)
@@ -676,7 +735,7 @@ class RAGEngine:
                     file_path=path_obj,
                     chunk_size=self.config.chunk_size,
                     chunk_overlap=self.config.chunk_overlap,
-                    embedding_model=self.config.embedding_model,
+                    embedding_model=model_name,
                     embedding_model_version=self.embedding_model_version,
                     file_type=mime_type,
                     num_chunks=len(documents),

--- a/tests/unit/embeddings/test_model_map.py
+++ b/tests/unit/embeddings/test_model_map.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from rag.embeddings.model_map import get_model_for_path, load_model_map
+
+
+def test_load_model_map(tmp_path: Path) -> None:
+    content = '"docs/*.md": text-embedding-3-small\nother.pdf: text-embedding-3-large\n'
+    yaml_file = tmp_path / "embeddings.yaml"
+    yaml_file.write_text(content)
+    model_map = load_model_map(yaml_file)
+    assert model_map["docs/*.md"] == "text-embedding-3-small"
+    assert model_map["other.pdf"] == "text-embedding-3-large"
+
+
+def test_get_model_for_path() -> None:
+    mapping = {"docs/*.md": "small", "reports/*": "large"}
+    assert get_model_for_path("docs/file.md", mapping, "default") == "small"
+    assert get_model_for_path("reports/annual.pdf", mapping, "default") == "large"
+    assert get_model_for_path("other.txt", mapping, "default") == "default"


### PR DESCRIPTION
## Summary
- add `embeddings.yaml` mapping file
- load mapping in `RAGEngine` and select model per file
- expose `embedding_model_map_file` config option
- document usage of `embeddings.yaml`
- add unit tests for the mapping utilities

## Testing
- `./check.sh`