### PR TITLE
Add docs publishing workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,62 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+      - 'README.md'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install uv
+        run: python -m pip install --upgrade pip uv
+
+      - name: Create virtualenv
+        run: uv venv .venv
+
+      - name: Install dependencies
+        run: |
+          . .venv/bin/activate
+          uv pip install -e .[dev]
+
+      - name: Build docs
+        run: |
+          . .venv/bin/activate
+          make -C docs html
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs/build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `invalidate`: Success/error messages
 - Autocomplete support in `rag repl` using `prompt_toolkit` for commands and file paths
 - Documented REPL autocomplete usage in README
+- GitHub Pages workflow to automatically build and publish Sphinx docs
 - Async embedding workers using `aiostream` for concurrent processing
 - `--max-workers` CLI flag to control async concurrency
 - Incremental indexing using chunk hashes to skip unchanged chunks

--- a/README.md
+++ b/README.md
@@ -332,6 +332,9 @@ make html
 
 Then open `docs/build/html/index.html` in your browser.
 
+The documentation site is automatically rebuilt and published to GitHub Pages
+whenever docs change on the `main` branch.
+
 ### Getting Help
 
 Show general help:

--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,6 @@
 
 ### 9 . Documentation & Examples
 - [#67] [P4] **Tutorial notebook** – `examples/rag_basic.ipynb` covering indexing, querying, prompt tweaks.
-- [#168] [P3] **Automatically publish docs** – Write a GitHub workflow or action to automatically rebuild and republish the sphinx docs to a GitHub pages site whenever the docs are changed
 
 ---
 


### PR DESCRIPTION
## Summary
- automate docs publishing with deploy-pages action
- document automatic GitHub Pages deployment
- remove completed TODO item
- note docs workflow in changelog

## Testing
- `ruff check src/rag`
- `./check.sh` *(fails: no network access for tests)*