### PR TITLE
Add stdio integration test

### DIFF
--- a/tests/integration/stdio_server_stub.py
+++ b/tests/integration/stdio_server_stub.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tests.unit.test_mcp_tools import _StubEngine
+from rag.mcp_server import mcp
+
+if __name__ == "__main__":
+    engine = _StubEngine([], {})
+    with patch("rag.mcp_tools.get_engine", return_value=engine):
+        mcp.run("stdio")

--- a/tests/integration/test_stdio_roundtrip.py
+++ b/tests/integration/test_stdio_roundtrip.py
@@ -1,0 +1,41 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from mcp.client.session import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.anyio
+async def test_stdio_roundtrip(tmp_path: Path) -> None:
+    """Index a document and query it via the stdio MCP server."""
+
+    doc = tmp_path / "doc.txt"
+    doc.write_text("hello")
+
+    root = Path(__file__).resolve().parents[1].parent
+    server_script = Path(__file__).with_name("stdio_server_stub.py")
+
+    server = StdioServerParameters(
+        command=sys.executable,
+        args=[str(server_script)],
+        env={"PYTHONPATH": str(root)},
+        cwd=str(root),
+    )
+
+    async with stdio_client(server) as (read, write):
+        async with ClientSession(read_stream=read, write_stream=write) as session:
+            await session.initialize()
+
+            result = await session.call_tool(
+                "index_path", {"path": str(doc)}
+            )
+            detail = json.loads(result.content[0].text)
+            assert "Indexed" in detail["detail"]
+
+            result = await session.call_tool("query", {"question": "hi"})
+            answer = json.loads(result.content[0].text)
+            assert answer["answer"] == "ok"


### PR DESCRIPTION
## Summary
- add helper script for running a stub MCP server via stdio
- test indexing and querying through the stdio MCP server

## Testing
- `./check.sh`