### PR TITLE
feat(mcp): remove legacy status and cache routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Outdated design sketch removed from `docs/design_sketches`.
 - Dropped experimental TUI interface and associated CSS
+- Legacy `/cache/clear` and `/system/status` HTTP endpoints removed in favour of MCP tools
 
 ### Changed
 - Log levels are now shown in uppercase for better readability

--- a/README.md
+++ b/README.md
@@ -300,21 +300,11 @@ rag invalidate --all path/to/directory
 ### MCP Server
 
 RAG operations are implemented as MCP tools in `rag.mcp_tools`. These tools can
-be served using the `FastMCP` server. The legacy FastAPI server still exposes a
-couple of endpoints for basic status and cache management:
-
-- `POST /cache/clear` – clear embedding and search caches.
-- `GET /system/status` – return server status and configuration summary.
+be served using the `FastMCP` server. The HTTP server exposes them via the
+standard MCP interface at the `/mcp` endpoint.
 
 Run the server with `rag mcp-http --host 127.0.0.1 --port 8000`. When
-`RAG_MCP_API_KEY` is set, include an `Authorization` header in requests:
-
-```bash
-curl -H "Authorization: Bearer $RAG_MCP_API_KEY" \
-  -X POST http://localhost:8000/cache/clear
-curl -H "Authorization: Bearer $RAG_MCP_API_KEY" \
-  http://localhost:8000/system/status
-```
+`RAG_MCP_API_KEY` is set, include an `Authorization` header in requests.
 
 AI assistants that implement MCP can connect using the same base URL and
 `Authorization` header.

--- a/TODO.md
+++ b/TODO.md
@@ -20,8 +20,6 @@
 
 ### MCP Server Integration
 
-- [#193] [P3] **Move remaining commands out of HTTP and into MCP** – According to the README, there are a couple of legacy HTTP endpoints still exposed -- /cache/clear and /system/status
-
 
 ### CLI / REPL UX
 

--- a/docs/source/api_http.md
+++ b/docs/source/api_http.md
@@ -34,9 +34,3 @@ Rebuild the entire index from scratch.
 
 ## GET `/index/stats`
 Return document count, total size, and chunk count.
-
-## POST `/cache/clear`
-Clear all cached embeddings and vector stores.
-
-## GET `/system/status`
-Return server status and configuration summary.

--- a/tests/integration/test_mcp_server_integration.py
+++ b/tests/integration/test_mcp_server_integration.py
@@ -28,7 +28,7 @@ def test_server_query() -> None:
     try:
         for _ in range(30):
             try:
-                httpx.get(f"http://127.0.0.1:{port}/system/status")
+                httpx.get(f"http://127.0.0.1:{port}/index/stats")
                 break
             except httpx.TransportError:
                 time.sleep(0.1)

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -23,17 +23,6 @@ def test_query_endpoint(socket_enabled) -> None:
     assert "answer" in data
 
 
-@patch("rag.mcp_server.get_engine")
-def test_system_status_endpoint(mock_get_engine: MagicMock, socket_enabled) -> None:
-    engine = _StubEngine([], {})
-    mock_get_engine.return_value = engine
-
-    response = client.get("/system/status")
-    assert response.status_code == 200
-    data = response.json()
-    assert data["status"] == "ok"
-    assert data["num_documents"] == 0
-    assert data["cache_dir"] == engine.config.cache_dir
 
 
 class _StubIndexMeta:
@@ -156,15 +145,6 @@ def test_index_endpoints(mock_get_engine: MagicMock, tmp_path: Path, socket_enab
     assert data["total_chunks"] == 1
 
 
-@patch("rag.mcp_server.get_engine")
-def test_cache_clear_endpoint(mock_get_engine: MagicMock, socket_enabled) -> None:
-    engine = _StubEngine([], {})
-    mock_get_engine.return_value = engine
-
-    response = client.post("/cache/clear")
-    assert response.status_code == 200
-    assert response.json() == {"detail": "Cache cleared"}
-    assert engine.cleared is True
 
 
 def test_authentication_required(monkeypatch, socket_enabled) -> None:
@@ -176,11 +156,11 @@ def test_authentication_required(monkeypatch, socket_enabled) -> None:
     reload(srv)
     client_auth = TestClient(srv.app)
 
-    resp = client_auth.get("/system/status")
+    resp = client_auth.get("/index/stats")
     assert resp.status_code == 401
 
     resp = client_auth.get(
-        "/system/status",
+        "/index/stats",
         headers={"Authorization": "Bearer tok"},
     )
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- remove legacy `/system/status` and `/cache/clear` endpoints
- adjust docs to reflect MCP-only interface
- update CHANGELOG
- drop endpoint tests and update auth checks

## Testing
- `./check.sh`