### PR TITLE
Improve README and move prompt docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ See the [Getting Started guide](https://0xSamQ.github.io/rag/getting_started.htm
 - Machine-readable JSON output for automation workflows
 - Synthetic QA generator for regression testing
 - MCP server for integrating RAG tools into other applications
+- Customizable prompts for different reasoning styles
 
+## Why RAG CLI?
+
+RAG CLI focuses on reliable local workflows. Many frameworks require a
+long-lived server or complex orchestration. This project keeps things
+simple: index your data, query it from the command line, and integrate
+the results into your own tools. Because it relies on standard LangChain
+components, you can swap vector stores or models without rewriting your
+pipeline. JSON output and a Python API make it easy to automate tasks
+or embed retrieval inside larger systems.
 
 ## Supported File Types
 
@@ -27,117 +37,6 @@ See the [Getting Started guide](https://0xSamQ.github.io/rag/getting_started.htm
 - RTF (`.rtf`)
 - ODT (`.odt`)
 - EPUB (`.epub`)
-
-
-## Customizing Prompts
-
-The RAG CLI supports different prompting strategies via the `--prompt` flag:
-
-```bash
-# Use chain-of-thought reasoning
-rag query "What is the key feature of RAG?" --prompt cot
-
-# Use a more conversational style
-rag repl --prompt creative
-```
-
-Available prompt templates:
-
-- `default`: Standard RAG prompt with citation guidance
-- `cot`: Chain-of-thought prompt encouraging step-by-step reasoning
-- `creative`: Engaging, conversational style while maintaining accuracy
-
-You can view all available prompts at any time:
-
-```bash
-rag prompt list
-```
-
-### Machine-Readable Output
-
-All commands support machine-readable JSON output through the `--json` flag. JSON output is also automatically enabled when the output is not a terminal (e.g., when piping to another command).
-
-```bash
-# Enable JSON output explicitly
-rag query "What are the main findings?" --json
-
-# JSON output is automatic when piping
-rag query "What are the main findings?" | jq .answer
-
-# List documents in JSON format
-rag list --json | jq '.table.rows[] | select(.[0] | contains(".pdf"))'
-
-# Get indexing results in JSON
-rag index docs/ --json | jq '.summary.total_files'
-```
-
-#### JSON Output Format
-
-Each command produces structured JSON output:
-
-1. Simple messages:
-   ```json
-   {
-     "message": "Successfully processed file.txt"
-   }
-   ```
-
-2. Error messages:
-   ```json
-   {
-     "error": "File not found: missing.txt"
-   }
-   ```
-
-3. Tables (e.g., from `rag list`):
-   ```json
-   {
-     "table": {
-       "title": "Indexed Documents",
-       "columns": ["File", "Type", "Modified", "Size"],
-       "rows": [
-         ["doc1.pdf", "PDF", "2024-03-20", "1.2MB"],
-         ["doc2.txt", "Text", "2024-03-19", "50KB"]
-       ]
-     }
-   }
-   ```
-
-4. Multiple tables:
-   ```json
-   {
-     "tables": [
-       {
-         "title": "Summary",
-         "columns": ["Metric", "Value"],
-         "rows": [["Total Files", "10"], ["Processed", "8"]]
-       },
-       {
-         "title": "Details",
-         "columns": ["File", "Status"],
-         "rows": [["file1.txt", "Success"], ["file2.pdf", "Error"]]
-       }
-     ]
-   }
-   ```
-
-5. Command-specific data (e.g., from `rag query`):
-   ```json
-   {
-     "answer": "The main findings are...",
-     "sources": [
-       {
-         "file": "paper.pdf",
-         "page": 12,
-         "text": "..."
-       }
-     ],
-     "metadata": {
-       "tokens_used": 150,
-       "model": "gpt-4"
-     }
- }
-  ```
 
 For development and testing instructions, see
 [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/source/customizing_prompts.md
+++ b/docs/source/customizing_prompts.md
@@ -1,0 +1,23 @@
+# Customizing Prompts
+
+The RAG CLI supports different prompting strategies via the `--prompt` flag:
+
+```bash
+# Use chain-of-thought reasoning
+rag query "What is the key feature of RAG?" --prompt cot
+
+# Use a more conversational style
+rag repl --prompt creative
+```
+
+Available prompt templates:
+
+- `default`: Standard RAG prompt with citation guidance
+- `cot`: Chain-of-thought prompt encouraging step-by-step reasoning
+- `creative`: Engaging, conversational style while maintaining accuracy
+
+You can view all available prompts at any time:
+
+```bash
+rag prompt list
+```

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,3 +14,5 @@ RAG Documentation
    swap_vector_store
    mcp_usage
    incremental_indexing
+   customizing_prompts
+   machine_readable_output

--- a/docs/source/machine_readable_output.md
+++ b/docs/source/machine_readable_output.md
@@ -1,0 +1,85 @@
+# Machine-Readable Output
+
+All commands support machine-readable JSON output through the `--json` flag. JSON output is also automatically enabled when the output is not a terminal (e.g., when piping to another command).
+
+```bash
+# Enable JSON output explicitly
+rag query "What are the main findings?" --json
+
+# JSON output is automatic when piping
+rag query "What are the main findings?" | jq .answer
+
+# List documents in JSON format
+rag list --json | jq '.table.rows[] | select(.[0] | contains(".pdf"))'
+
+# Get indexing results in JSON
+rag index docs/ --json | jq '.summary.total_files'
+```
+
+## JSON Output Format
+
+Each command produces structured JSON output:
+
+1. Simple messages:
+   ```json
+   {
+     "message": "Successfully processed file.txt"
+   }
+   ```
+
+2. Error messages:
+   ```json
+   {
+     "error": "File not found: missing.txt"
+   }
+   ```
+
+3. Tables (e.g., from `rag list`):
+   ```json
+   {
+     "table": {
+       "title": "Indexed Documents",
+       "columns": ["File", "Type", "Modified", "Size"],
+       "rows": [
+         ["doc1.pdf", "PDF", "2024-03-20", "1.2MB"],
+         ["doc2.txt", "Text", "2024-03-19", "50KB"]
+       ]
+     }
+   }
+   ```
+
+4. Multiple tables:
+   ```json
+   {
+     "tables": [
+       {
+         "title": "Summary",
+         "columns": ["Metric", "Value"],
+         "rows": [["Total Files", "10"], ["Processed", "8"]]
+       },
+       {
+         "title": "Details",
+         "columns": ["File", "Status"],
+         "rows": [["file1.txt", "Success"], ["file2.pdf", "Error"]]
+       }
+     ]
+   }
+   ```
+
+5. Command-specific data (e.g., from `rag query`):
+   ```json
+   {
+     "answer": "The main findings are...",
+     "sources": [
+       {
+         "file": "paper.pdf",
+         "page": 12,
+         "text": "..."
+       }
+     ],
+     "metadata": {
+       "tokens_used": 150,
+       "model": "gpt-4"
+     }
+ }
+  ```


### PR DESCRIPTION
## Summary
- expand features with marketing section on benefits
- move prompt customization and machine readable output sections out of README
- create new docs for customizing prompts and JSON output
- add both pages to docs index

## Testing
- `./check.sh`