### PR TITLE
Add loader and splitter metadata to cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--async-batching/--sync-batching` flag to control embedding batching mode
 - Incremental indexing using chunk hashes to skip unchanged chunks
 - Structured logging using structlog with Rich console output
+- Cache metadata records loader, tokenizer and text splitter used per file
   - Consistent error output format across all commands
   - Integration with tools like `jq` for output processing
   - Comprehensive test suite for JSON output functionality

--- a/docs/source/conceptual_overview.md
+++ b/docs/source/conceptual_overview.md
@@ -18,6 +18,7 @@ Every chunk retains the metadata added during loading plus additional fields suc
 
 ## 5. Vector Stores and Caching
 Embeddings are stored in a FAISS index managed by [VectorStoreManager](https://github.com/emerose/rag/blob/main/src/rag/storage/vectorstore.py). Each source file maps to ``.faiss`` and ``.pkl`` files under the ``.cache`` directory. [CacheManager](https://github.com/emerose/rag/blob/main/src/rag/storage/cache_manager.py) tracks these files and consults [IndexManager](https://github.com/emerose/rag/blob/main/src/rag/storage/index_manager.py) to decide when a vector store needs to be rebuilt. This caching keeps indexing fast while allowing stale entries to be invalidated or cleaned up.
+The index now also records which loader, tokenizer and text splitter were used for each file so indexing is reproducible.
 
 ## 6. Similarity Search and Retrieval
 Queries are answered by performing a dense similarity search over the cached vector stores. [HybridRetriever](https://github.com/emerose/rag/blob/main/src/rag/retrieval/hybrid_retriever.py) can combine BM25 with the dense search and [KeywordReranker](https://github.com/emerose/rag/blob/main/src/rag/retrieval/reranker.py) optionally re‑ranks results. The selected chunks become the context passed to the LLM.

--- a/src/rag/data/chunking.py
+++ b/src/rag/data/chunking.py
@@ -349,6 +349,9 @@ class SemanticChunkingStrategy(ChunkingStrategy):
             semantic_chunking=semantic_chunking,
         )
 
+        self.last_splitter_name: str | None = None
+        self.tokenizer_name = self.splitter_factory.tokenizer_name
+
     def _log(self, level: str, message: str) -> None:
         """Log a message.
 
@@ -379,5 +382,7 @@ class SemanticChunkingStrategy(ChunkingStrategy):
 
         # Use TextSplitterFactory to split documents
         chunked_docs = self.splitter_factory.split_documents(documents, mime_type)
+
+        self.last_splitter_name = self.splitter_factory.last_splitter_name
 
         return chunked_docs

--- a/src/rag/data/document_loader.py
+++ b/src/rag/data/document_loader.py
@@ -54,6 +54,7 @@ class DocumentLoader:
         self.filesystem_manager = filesystem_manager
         self.log_callback = log_callback
         self.metadata_extractor = DocumentMetadataExtractor()
+        self.last_loader_name: str | None = None
 
     def _log(self, level: str, message: str) -> None:
         """Log a message.
@@ -145,6 +146,7 @@ class DocumentLoader:
         # Get loader for the file
         try:
             loader = self.get_loader_for_file(file_path)
+            self.last_loader_name = loader.__class__.__name__
             self._log("DEBUG", f"Loading document: {file_path}")
             docs = loader.load()
 

--- a/src/rag/data/text_splitter.py
+++ b/src/rag/data/text_splitter.py
@@ -676,6 +676,10 @@ class TextSplitterFactory:
         # Initialize tokenizer
         self.tokenizer = _safe_encoding_for_model(model_name)
 
+        self.tokenizer_name = (
+            self.tokenizer.name if hasattr(self.tokenizer, "name") else "unknown"
+        )
+
         # Initialize default semantic splitter
         self.semantic_splitter = (
             SemanticRecursiveCharacterTextSplitter.from_tiktoken_encoder(
@@ -684,6 +688,8 @@ class TextSplitterFactory:
                 chunk_overlap=self.chunk_overlap,
             )
         )
+
+        self.last_splitter_name: str | None = None
 
         self._log(
             "DEBUG",
@@ -727,17 +733,23 @@ class TextSplitterFactory:
 
         # Create the appropriate splitter based on name
         if splitter_name == "markdown_header_splitter":
+            self.last_splitter_name = splitter_name
             return self._create_markdown_splitter()
         elif splitter_name == "html_splitter":
+            self.last_splitter_name = splitter_name
             return self._create_splitter_with_separators(config["separators"])
         elif splitter_name == "pdf_splitter":
+            self.last_splitter_name = splitter_name
             return self._create_splitter_with_separators(config["separators"])
         elif splitter_name == "token_splitter":
+            self.last_splitter_name = splitter_name
             return self._create_token_splitter()
         elif splitter_name == "document_splitter":
+            self.last_splitter_name = splitter_name
             return self._create_splitter_with_separators(config["separators"])
         else:
             # Default to semantic recursive character splitter
+            self.last_splitter_name = "semantic_splitter"
             return self.semantic_splitter
 
     def _create_splitter_with_separators(self, separators: list[str]) -> Any:

--- a/src/rag/engine.py
+++ b/src/rag/engine.py
@@ -469,6 +469,9 @@ class RAGEngine:
                 documents=documents,
                 file_type=ingest_result.source.mime_type or "text/plain",
                 embedding_model=model_name,
+                loader_name=ingest_result.source.loader_name,
+                tokenizer_name=ingest_result.source.tokenizer_name,
+                text_splitter_name=ingest_result.source.text_splitter_name,
             )
             return success, None
         except (
@@ -485,12 +488,15 @@ class RAGEngine:
             self._log("ERROR", f"Failed to index {file_path}: {error_message}")
             return False, error_message
 
-    def _create_vectorstore_from_documents(  # noqa: PLR0915, PLR0912
+    def _create_vectorstore_from_documents(  # noqa: PLR0915, PLR0912, PLR0913
         self,
         file_path: Path,
         documents: list[Document],
         file_type: str,
         embedding_model: str | None = None,
+        loader_name: str | None = None,
+        tokenizer_name: str | None = None,
+        text_splitter_name: str | None = None,
     ) -> bool:
         """Create or update a vectorstore from documents.
 
@@ -605,6 +611,9 @@ class RAGEngine:
                 embedding_model_version=self.embedding_model_version,
                 file_type=file_type,
                 num_chunks=len(documents),
+                document_loader=loader_name,
+                tokenizer=tokenizer_name,
+                text_splitter=text_splitter_name,
             )
 
             # Store chunk hashes for incremental indexing

--- a/tests/unit/storage/test_index_manager.py
+++ b/tests/unit/storage/test_index_manager.py
@@ -347,6 +347,9 @@ def test_update_metadata(
             embedding_model_version="test-version",
             file_type="text/plain",
             num_chunks=10,
+            document_loader="TextLoader",
+            tokenizer="cl100k_base",
+            text_splitter="semantic_splitter",
         )
 
     # Verify update_file_metadata was called with the right arguments
@@ -380,6 +383,9 @@ def test_get_metadata(_mock_connect: MagicMock, temp_dir: Path) -> None:
         "text/plain",  # file_type
         10,  # num_chunks
         12345,  # file_size
+        "TextLoader",  # document_loader
+        "cl100k_base",  # tokenizer
+        "semantic_splitter",  # text_splitter
     )
 
     # Create manager with mock
@@ -401,6 +407,9 @@ def test_get_metadata(_mock_connect: MagicMock, temp_dir: Path) -> None:
     assert metadata["file_type"] == "text/plain"
     assert metadata["num_chunks"] == 10
     assert metadata["file_size"] == 12345
+    assert metadata["document_loader"] == "TextLoader"
+    assert metadata["tokenizer"] == "cl100k_base"
+    assert metadata["text_splitter"] == "semantic_splitter"
 
 
 @patch("sqlite3.connect")


### PR DESCRIPTION
## Summary
- record which loader, tokenizer and text splitter were used for each indexed file
- expose last loader in `DocumentLoader`
- track splitter name and tokenizer in `TextSplitterFactory` and `SemanticChunkingStrategy`
- store the new metadata via `IndexManager`
- update documentation and tests

## Testing
- `./check.sh`