### PR TITLE
Add MCP parity features

### DIFF
--- a/docs/source/api_http.md
+++ b/docs/source/api_http.md
@@ -34,3 +34,16 @@ Rebuild the entire index from scratch.
 
 ## GET `/index/stats`
 Return document count, total size, and chunk count.
+
+## GET `/summaries`
+Return short summaries of indexed documents. Query parameter `k` controls the
+number of documents (default 5).
+
+## POST `/chunks`
+Retrieve stored chunks for a file. Payload: `{ "path": "./docs/file.txt" }`.
+
+## POST `/invalidate`
+Invalidate caches for a file or all caches when `{ "all": true }`.
+
+## POST `/cleanup`
+Remove orphaned vector stores and return summary statistics.


### PR DESCRIPTION
## Notes
- Implemented new MCP tools to mirror CLI commands, including summarize, chunks, invalidate and cleanup
- Added corresponding HTTP routes and updated unit tests
- Documented new endpoints

## Summary
- add DocumentSummary, Chunk and Cleanup models and new tool functions
- expose `/summaries`, `/chunks`, `/invalidate`, `/cleanup` routes
- register new tools with FastMCP server
- update API docs and test coverage

## Testing
- `./check.sh`