### PR TITLE
Allow custom OpenAI models

### DIFF
--- a/docs/source/cli_reference.md
+++ b/docs/source/cli_reference.md
@@ -119,3 +119,5 @@ Global options available on every command include:
 - `--json` – output machine-readable JSON
 - `--vectorstore-backend` – choose FAISS, Qdrant, or Chroma
 - `--max-workers` – number of concurrent tasks
+- `--embedding-model` – OpenAI embedding model (default `text-embedding-3-small`)
+- `--chat-model` – OpenAI chat model (default `gpt-4`)

--- a/docs/source/conceptual_overview.md
+++ b/docs/source/conceptual_overview.md
@@ -27,7 +27,7 @@ Queries are answered by performing a dense similarity search over the cached vec
 The RAG chains are assembled with LangChain Expression Language in [``build_rag_chain``](https://github.com/emerose/rag/blob/main/src/rag/chains/rag_chain.py). Prompt templates in ``prompts/`` define how retrieved text and the user question are combined. Chains may include system prompts or conversation history depending on the command.
 
 ## 8. Querying
-``rag query`` sends the assembled prompt to [ChatOpenAI](https://python.langchain.com/docs/integrations/chat/openai) (GPT‑4 by default) and returns the generated answer with source citations. The interactive ``rag repl`` maintains conversation state across turns and supports streaming output.
+``rag query`` sends the assembled prompt to [ChatOpenAI](https://python.langchain.com/docs/integrations/chat/openai) (GPT‑4 by default, configurable with ``--chat-model``) and returns the generated answer with source citations. The interactive ``rag repl`` maintains conversation state across turns and supports streaming output.
 
 ## 9. MCP and Tool Integration
 The Model Context Protocol (MCP) server exposes the same retrieval and generation capabilities. Clients like Claude or the Cursor editor can connect to the server, making it easy to integrate RAG results into other workflows.

--- a/src/rag/cli/cli.py
+++ b/src/rag/cli/cli.py
@@ -81,6 +81,8 @@ app.add_typer(prompt_app, name="prompt")
 CACHE_DIR = ".cache"
 MAX_K_VALUE = 20
 DEFAULT_MAX_WORKERS = get_optimal_concurrency()
+DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small"
+DEFAULT_CHAT_MODEL = "gpt-4"
 
 
 # Global state
@@ -94,6 +96,8 @@ class GlobalState:
     console: Console = console  # Store console instance
     vectorstore_backend: str = "faiss"
     max_workers: int = DEFAULT_MAX_WORKERS
+    embedding_model: str = DEFAULT_EMBEDDING_MODEL
+    chat_model: str = DEFAULT_CHAT_MODEL
 
 
 state = GlobalState()
@@ -116,6 +120,18 @@ VECTORSTORE_OPTION = typer.Option(
     "faiss",
     "--vectorstore-backend",
     help="Vector store backend (faiss, qdrant, chroma)",
+)
+
+EMBEDDING_MODEL_OPTION = typer.Option(
+    DEFAULT_EMBEDDING_MODEL,
+    "--embedding-model",
+    help="OpenAI embedding model to use",
+)
+
+CHAT_MODEL_OPTION = typer.Option(
+    DEFAULT_CHAT_MODEL,
+    "--chat-model",
+    help="OpenAI chat model to use",
 )
 
 MAX_WORKERS_OPTION = typer.Option(
@@ -202,6 +218,8 @@ def main(  # noqa: PLR0913
     ),
     vectorstore_backend: str = VECTORSTORE_OPTION,
     max_workers: int = MAX_WORKERS_OPTION,
+    embedding_model: str = EMBEDDING_MODEL_OPTION,
+    chat_model: str = CHAT_MODEL_OPTION,
     json_output: bool = JSON_OUTPUT_OPTION,
 ) -> None:
     """RAG (Retrieval Augmented Generation) CLI.
@@ -224,6 +242,8 @@ def main(  # noqa: PLR0913
     state.cache_dir = cache_dir
     state.vectorstore_backend = vectorstore_backend
     state.max_workers = max_workers
+    state.embedding_model = embedding_model
+    state.chat_model = chat_model
 
     # Set up signal handlers
     signal.signal(signal.SIGINT, signal_handler)
@@ -268,8 +288,8 @@ def _create_rag_config_and_runtime(
 
     config = RAGConfig(
         documents_dir=documents_dir,
-        embedding_model="text-embedding-3-small",
-        chat_model="gpt-4",
+        embedding_model=state.embedding_model,
+        chat_model=state.chat_model,
         temperature=0.0,
         chunk_size=params.chunk_size,
         chunk_overlap=params.chunk_overlap,
@@ -526,8 +546,8 @@ def invalidate(
         # Initialize RAG engine using RAGConfig
         config = RAGConfig(
             documents_dir=str(documents_dir),
-            embedding_model="text-embedding-3-small",
-            chat_model="gpt-4",
+            embedding_model=state.embedding_model,
+            chat_model=state.chat_model,
             temperature=0.0,
             cache_dir=cache_directory,
             vectorstore_backend=state.vectorstore_backend,
@@ -635,8 +655,8 @@ def query(  # noqa: PLR0913
         state.logger.debug("Initializing RAG engine...")
         config = RAGConfig(
             documents_dir=".",  # Not used for querying
-            embedding_model="text-embedding-3-small",
-            chat_model="gpt-4",
+            embedding_model=state.embedding_model,
+            chat_model=state.chat_model,
             temperature=0.0,
             cache_dir=cache_directory,
             vectorstore_backend=state.vectorstore_backend,
@@ -754,8 +774,8 @@ def summarize(
         state.logger.debug("Initializing RAG engine...")
         config = RAGConfig(
             documents_dir=".",  # Not used for summarization
-            embedding_model="text-embedding-3-small",
-            chat_model="gpt-4",
+            embedding_model=state.embedding_model,
+            chat_model=state.chat_model,
             temperature=0.0,
             cache_dir=cache_dir or state.cache_dir,
             vectorstore_backend=state.vectorstore_backend,
@@ -863,8 +883,8 @@ def list(
         state.logger.debug("Initializing RAG engine")
         config = RAGConfig(
             documents_dir=".",  # Not used for listing
-            embedding_model="text-embedding-3-small",
-            chat_model="gpt-4",
+            embedding_model=state.embedding_model,
+            chat_model=state.chat_model,
             temperature=0.0,
             cache_dir=cache_directory,
             vectorstore_backend=state.vectorstore_backend,
@@ -943,8 +963,8 @@ def chunks(
     try:
         config = RAGConfig(
             documents_dir=str(path.parent),
-            embedding_model="text-embedding-3-small",
-            chat_model="gpt-4",
+            embedding_model=state.embedding_model,
+            chat_model=state.chat_model,
             temperature=0.0,
             cache_dir=cache_dir or state.cache_dir,
             vectorstore_backend=state.vectorstore_backend,
@@ -988,8 +1008,8 @@ def _initialize_rag_engine(runtime_options: RuntimeOptions | None = None) -> RAG
     """Initialize and return a RAGEngine instance."""
     config = RAGConfig(
         documents_dir=".",  # Not used for querying
-        embedding_model="text-embedding-3-small",
-        chat_model="gpt-4",
+        embedding_model=state.embedding_model,
+        chat_model=state.chat_model,
         temperature=0.0,
         cache_dir=state.cache_dir,
         vectorstore_backend=state.vectorstore_backend,

--- a/tests/unit/cli/test_model_options.py
+++ b/tests/unit/cli/test_model_options.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from rag.cli.cli import app
+
+
+def test_custom_models_passed_to_engine(tmp_path: Path) -> None:
+    runner = CliRunner()
+    engine_instance = MagicMock()
+    engine_instance.index_meta.list_indexed_files.return_value = []
+    with patch("rag.cli.cli.RAGEngine", return_value=engine_instance) as mock_engine:
+        result = runner.invoke(
+            app,
+            [
+                "--embedding-model",
+                "custom-embed",
+                "--chat-model",
+                "custom-chat",
+                "list",
+                "--cache-dir",
+                str(tmp_path),
+            ],
+        )
+    assert result.exit_code == 0
+    config = mock_engine.call_args.args[0]
+    assert config.embedding_model == "custom-embed"
+    assert config.chat_model == "custom-chat"


### PR DESCRIPTION
## Summary
- add `--embedding-model` and `--chat-model` CLI options
- store values in global state and use in configuration helpers
- update docs with the new options
- test that custom models are passed to `RAGEngine`

## Testing
- `./check.sh`