### PR TITLE
Add pytest-asyncio to dev requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ Thank you for your interest in improving this project! This guide explains how t
    ```bash
    uv pip install -e ".[dev]"
    ```
+   This installs packages required for development, including
+   `pytest-asyncio` for running asynchronous tests.
 4. **Set your OpenAI API key** in a `.env` file:
    ```bash
    echo "OPENAI_API_KEY=your-api-key" > .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "mypy>=1.8.0",
     "pre-commit>=3.6.0",
     "pytest>=8.3.0",
+    "pytest-asyncio>=1.0.0",
     "pytest-cov>=6.1.0",
     "pytest-socket>=0.6.0",
     "hatch>=1.9.0",


### PR DESCRIPTION
## Summary
- include `pytest-asyncio` in the dev extras list
- mention the package in CONTRIBUTING

## Testing
- `./check.sh` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*