### PR TITLE
Add MCP server API integration tests

### DIFF
--- a/tests/integration/test_mcp_server_api.py
+++ b/tests/integration/test_mcp_server_api.py
@@ -1,0 +1,82 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+from fastmcp import Client
+from langchain_core.documents import Document
+from starlette.testclient import TestClient
+
+from rag.config import RAGConfig, RuntimeOptions
+from rag.mcp import build_server, create_http_app
+
+pytestmark = pytest.mark.integration
+
+
+def _build_test_server(tmp_path: Path):
+    config = RAGConfig(
+        documents_dir=str(tmp_path / "docs"),
+        cache_dir=str(tmp_path / "cache"),
+        openai_api_key="sk-test",
+    )
+    runtime = RuntimeOptions()
+    server = build_server(config, runtime)
+
+    engine = server.engine
+    engine.answer = lambda q, k=4: {"answer": "ok"}
+    engine.vectorstores = {"vs": object()}
+    engine.vectorstore_manager.merge_vectorstores = lambda stores: None
+    engine.vectorstore_manager.similarity_search = (
+        lambda merged, q, k=4: [Document(page_content="doc", metadata={})]
+    )
+    engine.index_directory = lambda path: {"indexed": True}
+    engine.index_file = lambda path: (True, "")
+    engine.invalidate_all_caches = lambda: None
+    engine.list_indexed_files = lambda: [
+        {"file_path": "sample.txt", "num_chunks": 1, "file_size": 1}
+    ]
+    engine.invalidate_cache = lambda path: None
+    engine.get_document_summaries = lambda k=5: [
+        {"path": "sample.txt", "summary": "dummy"}
+    ]
+    engine.index_manager.get_chunk_hashes = lambda path: ["chunk1"]
+    engine.cleanup_orphaned_chunks = lambda: {"removed": 0}
+    return server
+
+
+@pytest.mark.asyncio
+async def test_stdio_transport(tmp_path: Path) -> None:
+    server = _build_test_server(tmp_path)
+    client = Client(server)
+    async with client:
+        assert (await client.call_tool("tool_query", {"question": "hi"}))[0].text
+        await client.call_tool("tool_search", {"query": "hi"})
+        await client.call_tool("tool_index", {"path": "."})
+        await client.call_tool("tool_rebuild")
+        await client.call_tool("tool_index_stats")
+        await client.call_tool("tool_documents")
+        await client.call_tool("tool_get_document", {"path": "sample.txt"})
+        await client.call_tool("tool_delete_document", {"path": "sample.txt"})
+        await client.call_tool("tool_summaries")
+        await client.call_tool("tool_chunks", {"path": "sample.txt"})
+        await client.call_tool("tool_invalidate", {"all": True})
+        await client.call_tool("tool_cleanup")
+
+
+def test_http_transport(tmp_path: Path) -> None:
+    server = _build_test_server(tmp_path)
+    app = create_http_app(server)
+    client = TestClient(app)
+
+    assert client.post("/query", json={"question": "hi", "top_k": 1}).status_code == 200
+    assert client.post("/search", json={"query": "hi", "top_k": 1}).status_code == 200
+    assert client.post("/chat", json={"session_id": "1", "message": "hi"}).status_code == 200
+    assert client.get("/documents").status_code == 200
+    assert client.get("/documents/sample.txt").status_code == 200
+    assert client.delete("/documents/sample.txt").status_code == 200
+    assert client.post("/index", json={"path": "."}).status_code == 200
+    assert client.post("/index/rebuild").status_code == 200
+    assert client.get("/index/stats").status_code == 200
+    assert client.get("/summaries").status_code == 200
+    assert client.post("/chunks", json={"path": "sample.txt"}).status_code == 200
+    assert client.post("/invalidate", json={"all": True}).status_code == 200
+    assert client.post("/cleanup").status_code == 200


### PR DESCRIPTION
## Summary
- expand MCP server integration tests to exercise every API
  using both stdio and HTTP transports

## Testing
- `./check.sh`