### PR TITLE
Fix integration tests to use OPENAI_API_KEY

### DIFF
--- a/tests/integration/test_eval_rag.py
+++ b/tests/integration/test_eval_rag.py
@@ -30,11 +30,16 @@ def test_golden_set_retrieval(tmp_path: Path) -> None:
     target_file = docs_dir / "sample.txt"
     shutil.copy(sample_file, target_file)
 
-    config = RAGConfig(documents_dir=str(docs_dir), cache_dir=str(cache_dir), openai_api_key="sk-test")
+    config = RAGConfig(documents_dir=str(docs_dir), cache_dir=str(cache_dir))
     runtime = RuntimeOptions()
 
-    with patch("rag.embeddings.embedding_provider.OpenAIEmbeddings", return_value=FakeEmbeddings(size=32)), \
-            patch.object(EmbeddingProvider, "_get_embedding_dimension", return_value=32):
+    with (
+        patch(
+            "rag.embeddings.embedding_provider.OpenAIEmbeddings",
+            return_value=FakeEmbeddings(size=32),
+        ),
+        patch.object(EmbeddingProvider, "_get_embedding_dimension", return_value=32),
+    ):
         engine = RAGEngine(config, runtime)
         success, error = engine.index_file(target_file)
         assert success, f"Indexing failed: {error}"
@@ -43,7 +48,9 @@ def test_golden_set_retrieval(tmp_path: Path) -> None:
         hits = 0
         contains_answer = 0
         for question, expected_sentence in GOLDEN_QA:
-            docs = engine.vectorstore_manager.similarity_search(vectorstore, question, k=1)
+            docs = engine.vectorstore_manager.similarity_search(
+                vectorstore, question, k=1
+            )
             assert docs, "No documents retrieved"
             doc_text = docs[0].page_content.strip()
             if expected_sentence.lower() in doc_text.lower():

--- a/tests/integration/test_mcp_server_api.py
+++ b/tests/integration/test_mcp_server_api.py
@@ -16,7 +16,6 @@ def _build_test_server(tmp_path: Path):
     config = RAGConfig(
         documents_dir=str(tmp_path / "docs"),
         cache_dir=str(tmp_path / "cache"),
-        openai_api_key="sk-test",
     )
     runtime = RuntimeOptions()
     server = build_server(config, runtime)
@@ -25,9 +24,9 @@ def _build_test_server(tmp_path: Path):
     engine.answer = lambda q, k=4: {"answer": "ok"}
     engine.vectorstores = {"vs": object()}
     engine.vectorstore_manager.merge_vectorstores = lambda stores: None
-    engine.vectorstore_manager.similarity_search = (
-        lambda merged, q, k=4: [Document(page_content="doc", metadata={})]
-    )
+    engine.vectorstore_manager.similarity_search = lambda merged, q, k=4: [
+        Document(page_content="doc", metadata={})
+    ]
     engine.index_directory = lambda path: {"indexed": True}
     engine.index_file = lambda path: (True, "")
     engine.invalidate_all_caches = lambda: None
@@ -69,7 +68,10 @@ def test_http_transport(tmp_path: Path) -> None:
 
     assert client.post("/query", json={"question": "hi", "top_k": 1}).status_code == 200
     assert client.post("/search", json={"query": "hi", "top_k": 1}).status_code == 200
-    assert client.post("/chat", json={"session_id": "1", "message": "hi"}).status_code == 200
+    assert (
+        client.post("/chat", json={"session_id": "1", "message": "hi"}).status_code
+        == 200
+    )
     assert client.get("/documents").status_code == 200
     assert client.get("/documents/sample.txt").status_code == 200
     assert client.delete("/documents/sample.txt").status_code == 200


### PR DESCRIPTION
## Summary
- remove hard-coded OpenAI key from integration tests
- rely on OPENAI_API_KEY environment variable instead

## Testing
- `./check.sh`