### PR TITLE
Add --log-file option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `--async-batching/--sync-batching` flag to control embedding batching mode
 - Incremental indexing using chunk hashes to skip unchanged chunks
 - Structured logging using structlog with Rich console output
+- `--log-file` CLI option to direct logs to a file
 - Cache metadata records loader, tokenizer and text splitter used per file
   - Consistent error output format across all commands
   - Integration with tools like `jq` for output processing

--- a/docs/source/cli_reference.md
+++ b/docs/source/cli_reference.md
@@ -115,3 +115,4 @@ Global options available on every command include:
 - `--max-workers` – number of concurrent tasks
 - `--embedding-model` – OpenAI embedding model (default `text-embedding-3-small`)
 - `--chat-model` – OpenAI chat model (default `gpt-4`)
+- `--log-file` – write logs to the specified file

--- a/src/rag/cli/cli.py
+++ b/src/rag/cli/cli.py
@@ -100,6 +100,7 @@ class GlobalState:
     max_workers: int = DEFAULT_MAX_WORKERS
     embedding_model: str = DEFAULT_EMBEDDING_MODEL
     chat_model: str = DEFAULT_CHAT_MODEL
+    log_file: str | None = None
 
 
 state = GlobalState()
@@ -143,6 +144,12 @@ MAX_WORKERS_OPTION = typer.Option(
     help="Maximum concurrent worker tasks",
 )
 
+LOG_FILE_OPTION = typer.Option(
+    None,
+    "--log-file",
+    help="Write logs to the specified file instead of stderr",
+)
+
 # Define argument defaults outside functions
 INVALIDATE_PATH_ARG = typer.Argument(
     None,
@@ -173,11 +180,11 @@ def update_console_for_json_mode(json_mode: bool) -> None:
 
 
 def configure_logging(
-    verbose: bool, log_level: LogLevel, json_logs: bool
+    verbose: bool, log_level: LogLevel, json_logs: bool, log_file: str | None
 ) -> logging.Logger:
-    """Configure logging based on verbosity settings."""
+    """Configure logging based on CLI options."""
     level = logging.INFO if verbose else getattr(logging, log_level.value)
-    setup_logging(log_level=level, json_logs=json_logs)
+    setup_logging(log_file=log_file, log_level=level, json_logs=json_logs)
     return get_logger()
 
 
@@ -231,6 +238,7 @@ def main(  # noqa: PLR0913
     max_workers: int = MAX_WORKERS_OPTION,
     embedding_model: str = EMBEDDING_MODEL_OPTION,
     chat_model: str = CHAT_MODEL_OPTION,
+    log_file: str | None = LOG_FILE_OPTION,
     json_output: bool = JSON_OUTPUT_OPTION,
 ) -> None:
     """RAG (Retrieval Augmented Generation) CLI.
@@ -247,7 +255,8 @@ def main(  # noqa: PLR0913
     update_console_for_json_mode(json_mode)
 
     # Configure logging
-    state.logger = configure_logging(verbose, log_level, json_mode)
+    state.log_file = log_file
+    state.logger = configure_logging(verbose, log_level, json_mode, log_file)
 
     # Set cache directory
     state.cache_dir = cache_dir


### PR DESCRIPTION
## Summary
- add `--log-file` CLI option to direct logging output to a file
- default to logging to stderr when no file is provided
- document the option and update changelog
- test new behaviour in logging utils

## Testing
- `./check.sh`