### PR TITLE
Fix async indexing error

### DIFF
--- a/src/rag/mcp/server.py
+++ b/src/rag/mcp/server.py
@@ -86,13 +86,15 @@ class RAGMCPServer(FastMCP):
     async def tool_index(self, path: str) -> dict[str, Any]:
         p = Path(path)
         if p.is_dir():
-            return self.engine.index_directory(p)
-        success, error = self.engine.index_file(p)
+            return await asyncio.to_thread(self.engine.index_directory, p)
+        success, error = await asyncio.to_thread(self.engine.index_file, p)
         return {"success": success, "error": error}
 
     async def tool_rebuild(self) -> dict[str, Any]:
         self.engine.invalidate_all_caches()
-        return self.engine.index_directory(self.engine.documents_dir)
+        return await asyncio.to_thread(
+            self.engine.index_directory, self.engine.documents_dir
+        )
 
     async def tool_index_stats(self) -> dict[str, Any]:
         files = self.engine.list_indexed_files()

--- a/tests/unit/test_mcp_thread_index.py
+++ b/tests/unit/test_mcp_thread_index.py
@@ -1,0 +1,29 @@
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from rag.mcp.server import RAGMCPServer
+
+
+class DummyEngine:
+    def __init__(self, base: Path) -> None:
+        self.documents_dir = base
+
+    def index_directory(self, path: Path):
+        asyncio.run(asyncio.sleep(0))
+        return {"success": True}
+
+    def index_file(self, path: Path):
+        asyncio.run(asyncio.sleep(0))
+        return True, None
+
+    def invalidate_all_caches(self) -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_tool_index_runs_in_thread(tmp_path: Path) -> None:
+    server = RAGMCPServer(engine=DummyEngine(tmp_path))
+    result = await server.tool_index(str(tmp_path))
+    assert result["success"]


### PR DESCRIPTION
## Summary
- run engine index operations in a thread from MCP tools
- add regression test for async server indexing

## Testing
- `./check.sh`