### PR TITLE
Add progress reporting for MCP indexing

### DIFF
--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -69,3 +69,36 @@ def test_call_tool_logs_name_and_args(tmp_path, caplog):
         and getattr(record, "arguments", None) == {"question": "hi"}
         for record in caplog.records
     )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "needs,success,error,expected",
+    [
+        (False, True, None, "cached"),
+        (True, True, None, "indexed"),
+        (True, False, "boom", "error"),
+    ],
+)
+async def test_tool_index_reports_progress(tmp_path, needs, success, error, expected):
+    config = _dummy_config(tmp_path)
+    runtime = RuntimeOptions()
+    server = build_server(config, runtime)
+
+    file_path = tmp_path / "docs" / "f.txt"
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text("hi")
+
+    ctx = MagicMock()
+    ctx.report_progress = AsyncMock()
+
+    with (
+        patch.object(
+            server.engine.index_manager, "needs_reindexing", return_value=needs
+        ),
+        patch.object(server.engine, "index_file", return_value=(success, error)),
+    ):
+        await server.tool_index(str(file_path), ctx)
+
+    assert expected in ctx.report_progress.call_args.args[2]


### PR DESCRIPTION
## Summary
- stream progress messages for the `tool_index` MCP tool
- test progress message emission when indexing via MCP

## Testing
- `./check.sh`