### PR TITLE
Fix async batching when loop already running

### DIFF
--- a/src/rag/engine.py
+++ b/src/rag/engine.py
@@ -33,6 +33,7 @@ from .storage.filesystem import FilesystemManager
 from .storage.index_manager import IndexManager
 from .storage.protocols import VectorStoreProtocol
 from .storage.vectorstore import VectorStoreManager
+from .utils.async_utils import run_coro_sync
 from .utils.logging_utils import log_message
 
 logger = logging.getLogger(__name__)
@@ -599,7 +600,7 @@ class RAGEngine:
                     f"Generating embeddings for {len(docs_to_embed)} new/changed documents",
                 )
                 if self.runtime.async_batching:
-                    embeddings = asyncio.run(
+                    embeddings = run_coro_sync(
                         batcher.process_embeddings_async(docs_to_embed)
                     )
                 else:

--- a/tests/unit/utils/test_async_utils.py
+++ b/tests/unit/utils/test_async_utils.py
@@ -9,6 +9,7 @@ from rag.utils.async_utils import (
     AsyncBatchProcessor,
     get_optimal_concurrency,
     yield_control,
+    run_coro_sync,
 )
 
 
@@ -40,4 +41,21 @@ async def test_yield_control_returns_none() -> None:
     """Yielding control should simply return."""
     result = await yield_control()
     assert result is None
+
+
+def test_run_coro_sync_from_sync() -> None:
+    async def coro() -> int:
+        await asyncio.sleep(0)
+        return 42
+
+    assert run_coro_sync(coro()) == 42
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_from_async() -> None:
+    async def coro() -> int:
+        await asyncio.sleep(0)
+        return 24
+
+    assert run_coro_sync(coro()) == 24
 


### PR DESCRIPTION
## Summary
- add `run_coro_sync` helper to execute a coroutine from sync code regardless of event loop state
- use `run_coro_sync` in `RAGEngine` to avoid `asyncio.run` errors during indexing
- test `run_coro_sync` in both sync and async contexts

## Testing
- `./check.sh`