### PR TITLE
Implement documentation generation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,5 +157,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added pytest-asyncio dependency for async test support
 - Improved test coverage for MCP server components
 - Enhanced cross-platform compatibility for path handling
+- Added generate_docs.py for auto-generated API documentation
 
 ## [0.1.0] - 2024-12-XX

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ or embed retrieval inside larger systems.
 For development and testing instructions, see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Building documentation
+
+Run `python scripts/generate_docs.py` to generate API docs and build HTML output in `docs/build`.
+
 ## License
 
 MIT License - see [LICENSE](LICENSE)

--- a/TODO.md
+++ b/TODO.md
@@ -60,7 +60,6 @@
 
 ### Documentation & Examples
 - [#67] [P4] **Tutorial notebook** – `examples/rag_basic.ipynb` covering indexing, querying, prompt tweaks.
-- [#246] [P4] **Documentation generation** – Auto-generate API documentation from code
 
 ---
 

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Generate API documentation using Sphinx.
+
+This script runs ``sphinx-apidoc`` to create reStructuredText files for
+all modules in the ``rag`` package and then builds the HTML
+documentation. The generated files are placed under ``docs/build``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = ROOT / "docs"
+SOURCE_DIR = DOCS_DIR / "source"
+API_DIR = SOURCE_DIR / "api"
+
+
+def generate_apidocs() -> None:
+    """Generate ``.rst`` files for the ``rag`` package."""
+    API_DIR.mkdir(exist_ok=True)
+    subprocess.run(
+        [
+            "sphinx-apidoc",
+            "--module-first",
+            "--force",
+            "-o",
+            str(API_DIR),
+            str(ROOT / "src" / "rag"),
+        ],
+        check=True,
+    )
+
+
+def build_html() -> None:
+    """Build the HTML documentation."""
+    subprocess.run(
+        [
+            "sphinx-build",
+            "-M",
+            "html",
+            str(SOURCE_DIR),
+            str(DOCS_DIR / "build"),
+        ],
+        check=True,
+    )
+
+
+def main() -> None:
+    """Generate API docs and build HTML output."""
+    generate_apidocs()
+    build_html()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `generate_docs.py` utility to build API documentation with Sphinx
- document doc generation in README
- note new script in changelog
- remove completed task from TODO

## Testing
- `./check.sh`