### PR TITLE
Fix ChatOpenAI patch in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Ensured cache directory separation from documents directory
   - Prevented cache files from being indexed as documents
 - Fixed relative import causing `ModuleNotFoundError` when running CLI as a module
+- Fixed ChatOpenAI patch path in integration tests
 
 ### Technical Debt
 - Added pytest-asyncio dependency for async test support

--- a/tests/integration/test_extended_workflows.py
+++ b/tests/integration/test_extended_workflows.py
@@ -213,7 +213,7 @@ def test_json_output_piping(tmp_path: Path) -> None:
             return_value=FakeEmbeddings(size=8),
         ),
         patch.object(EmbeddingProvider, "_get_embedding_dimension", return_value=8),
-        patch("rag.cli.cli.ChatOpenAI"),
+        patch("rag.engine.ChatOpenAI"),
     ):
         result_index = runner.invoke(
             app, ["index", str(file_path), "--cache-dir", str(tmp_path)]


### PR DESCRIPTION
## Summary
- patch `ChatOpenAI` in `rag.engine` rather than `rag.cli.cli`
- note test fix in changelog

## Testing
- `./check.sh`