### PR TITLE
Integrate OpenEvals into evaluation design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `summarize`: Table of document summaries
     - `cleanup`: Summary of removed files
 - Synthetic QA generator script for creating regression test data
-- Evaluation framework design sketch in docs
+- Evaluation framework design sketch in docs; updated to use OpenEvals for
+  subsystem metrics
     - `invalidate`: Success/error messages
 - Autocomplete support in `rag repl` using `prompt_toolkit` for commands and file paths
 - Documented REPL autocomplete usage in README

--- a/TODO.md
+++ b/TODO.md
@@ -51,6 +51,9 @@
 
 ### Evaluation & Testing
 
+- [P3] **OpenEvals integration** – Evaluate subsystem performance using the
+  OpenEvals library
+
 
 
 ### Packaging & CI

--- a/docs/source/evaluation_framework.md
+++ b/docs/source/evaluation_framework.md
@@ -7,7 +7,9 @@ regressions over time.
 ## Objectives
 - Measure performance of document loading, text splitting, indexing, retrieval and answer generation.
 - Track metrics such as latency, token counts, recall/precision and generated answer quality.
-- Provide a reproducible benchmark harness using open source tools.
+- Provide a reproducible benchmark harness using open source tools such as
+  [OpenEvals](https://github.com/open-evals/openevals).
+- Leverage OpenEvals to evaluate the performance of each subsystem.
 
 ## Key Components
 1. **Dataset management**
@@ -37,6 +39,9 @@ regressions over time.
    - Store metrics in CSV/JSON files via [`pandas`](https://pandas.pydata.org/).
    - Generate plots with [`matplotlib`](https://matplotlib.org/) or [`seaborn`](https://seaborn.pydata.org/).
    - Compare historical runs to highlight improvements or regressions.
+7. **OpenEvals integration**
+   - Use [OpenEvals](https://github.com/open-evals/openevals) tasks to compute
+     standard metrics across retrieval and generation subsystems.
 
 ## Automation
 - Provide a `rag eval` CLI command that runs the full suite and outputs a summary table.
@@ -52,8 +57,12 @@ The following incremental steps outline how to build the evaluation framework. E
 1. **Define dataset and config models** – Create Pydantic models for datasets and evaluation settings stored under `tests/data/`.
 2. **Implement dataset loading with metrics** – Build loaders that track file type, size and parsing time, adding unit tests for failure cases.
 3. **Add text splitting instrumentation** – Log chunk sizes and token counts via `tiktoken`; test with small sample documents.
-4. **Capture indexing and retrieval metrics** – Measure FAISS indexing throughput, memory usage and retrieval quality (recall@k, MRR) against ground truth pairs.
-5. **Instrument query and generation** – Mock the OpenAI API to collect latency and token stats, then compute answer similarity using `sacrebleu`.
+4. **Capture indexing and retrieval metrics** – Measure FAISS indexing throughput
+   and memory usage, then compute recall@k and MRR with
+   [OpenEvals](https://github.com/open-evals/openevals) tasks.
+5. **Instrument query and generation** – Mock the OpenAI API to collect latency
+   and token stats, then evaluate answer quality using OpenEvals similarity
+   metrics.
 6. **Persist metrics to files** – Write results to CSV/JSON with `pandas` and generate simple plots using `matplotlib`.
 7. **Create `rag eval` CLI command** – Wire components together behind a CLI entry point that prints a summary table.
 8. **Write unit tests for the CLI and metrics** – Ensure core functions behave deterministically and cover error scenarios.


### PR DESCRIPTION
## Summary
- document using OpenEvals to evaluate subsystems
- add OpenEvals roadmap item
- note the change in the changelog

## Testing
- `./check.sh`