### PR TITLE
Add retrieval evaluator for BEIR datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BEIR dataset uploader script for LangSmith integration
 - Evaluation framework design sketch in docs; updated to use OpenEvals for
   subsystem metrics
+- Initial retrieval evaluator indexing the BEIR Scifact dataset
     - `invalidate`: Success/error messages
 - Autocomplete support in `rag repl` using `prompt_toolkit` for commands and file paths
 - Documented REPL autocomplete usage in README

--- a/docs/source/evaluation_framework.md
+++ b/docs/source/evaluation_framework.md
@@ -14,6 +14,7 @@ regressions over time.
 ## Key Components
 1. **Dataset management**
    - Use a small collection of documents and question/answer pairs (e.g. samples from the [BEIR](https://github.com/beir-datasets/beir) dataset).
+   - The retrieval evaluator downloads the `scifacts` dataset from Hugging Face and indexes the corpus under a dedicated `.cache-evals` directory.
    - Store datasets under `tests/data/` so evaluations run offline.
    - Pydantic models define dataset schema and evaluation configuration.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "filelock>=3.12.0",
     "aiostream>=0.6.4",
     "beir>=1.0.0",
+    "datasets>=2.18.0",
     "pyyaml>=6.0",
     "fastmcp>=2.5.1",
 ]

--- a/src/rag/evaluation/retrieval.py
+++ b/src/rag/evaluation/retrieval.py
@@ -1,18 +1,96 @@
-"""Dummy retrieval evaluator."""
+"""Retrieval evaluator leveraging BEIR datasets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from rag.config import RAGConfig, RuntimeOptions
+from rag.engine import RAGEngine
+from rag.storage.vectorstore import VectorStoreManager
 
 from .types import Evaluation, EvaluationResult
 
 
 class RetrievalEvaluator:
-    """Evaluator for retrieval metrics."""
+    """Evaluator for retrieval metrics using BEIR datasets."""
 
     def __init__(self, evaluation: Evaluation) -> None:
-        """Initialize with evaluation configuration."""
+        """Store evaluation configuration."""
         self.evaluation = evaluation
 
+    # Internal helpers -------------------------------------------------
+    def _index_corpus(self, cache_dir: Path) -> RAGEngine:
+        """Download and index the Scifact corpus."""
+        from datasets import load_dataset
+
+        dataset = load_dataset("BeIR/scifacts", "corpus", split="corpus")
+        docs_dir = cache_dir / "scifacts-corpus"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+
+        for item in dataset:
+            doc_id = item.get("doc_id") or item.get("_id") or item["id"]
+            title = item.get("title", "")
+            text = item.get("text") or item.get("abstract") or ""
+            path = docs_dir / f"{doc_id}.txt"
+            if not path.exists():
+                path.write_text(f"{title}\n\n{text}")
+
+        config = RAGConfig(documents_dir=str(docs_dir), cache_dir=str(cache_dir))
+        engine = RAGEngine(config, RuntimeOptions())
+        engine.index_directory(docs_dir)
+        return engine
+
+    def _run_retrieval(
+        self, engine: RAGEngine, queries: list[dict[str, Any]], k: int
+    ) -> dict[str, dict[str, float]]:
+        """Run similarity search for each query and return ranking results."""
+        vs_manager: VectorStoreManager = engine.vectorstore_manager
+        merged_vs = vs_manager.merge_vectorstores(list(engine.vectorstores.values()))
+        results: dict[str, dict[str, float]] = {}
+        for q in queries:
+            qid = q.get("query_id") or q.get("_id") or q["id"]
+            text = q.get("text") or q.get("query")
+            docs = vs_manager.similarity_search(merged_vs, text, k=k)
+            scores = {
+                d.metadata.get("source", str(idx)): 1.0 / (idx + 1)
+                for idx, d in enumerate(docs)
+            }
+            results[str(qid)] = scores
+        return results
+
+    # Public API -------------------------------------------------------
     def evaluate(self) -> EvaluationResult:
-        """Return placeholder metrics for now."""
-        metrics = {metric: 0.0 for metric in self.evaluation.metrics}
+        """Index the dataset and compute retrieval metrics."""
+        from beir.retrieval.evaluation import EvaluateRetrieval
+        from datasets import load_dataset
+
+        cache_dir = Path(".cache-evals")
+        cache_dir.mkdir(exist_ok=True)
+
+        engine = self._index_corpus(cache_dir)
+
+        queries = load_dataset("BeIR/scifacts", "queries", split="test")
+        qrels = load_dataset("BeIR/scifacts", "qrels", split="test")
+
+        query_list = [dict(q) for q in queries]
+        results = self._run_retrieval(engine, query_list, k=10)
+
+        qrels_dict: dict[str, dict[str, int]] = {}
+        for row in qrels:
+            qid = str(row.get("query_id") or row.get("_id") or row["id"])
+            doc_id = str(row.get("doc_id") or row.get("corpus_id"))
+            score = int(row.get("score", 1))
+            qrels_dict.setdefault(qid, {})[doc_id] = score
+
+        evaluator = EvaluateRetrieval()
+        metrics_result = evaluator.evaluate(qrels_dict, results, k_values=[10])
+
+        metrics = {
+            metric: float(metrics_result.get(metric, {10: 0.0}).get(10, 0.0))
+            for metric in self.evaluation.metrics
+        }
+
         return EvaluationResult(
             category=self.evaluation.category,
             test=self.evaluation.test,

--- a/tests/unit/evaluation/test_retrieval_evaluator.py
+++ b/tests/unit/evaluation/test_retrieval_evaluator.py
@@ -1,0 +1,28 @@
+from unittest.mock import MagicMock, patch
+
+from rag.evaluation.retrieval import RetrievalEvaluator
+from rag.evaluation.types import Evaluation
+
+
+def test_retrieval_evaluator_uses_beir() -> None:
+    evaluation = Evaluation(category="retrieval", test="scifacts", metrics=["ndcg@10"])
+
+    with (
+        patch.object(RetrievalEvaluator, "_index_corpus") as mock_index,
+        patch("datasets.load_dataset") as mock_load,
+        patch("beir.retrieval.evaluation.EvaluateRetrieval") as mock_eval,
+    ):
+        mock_engine = MagicMock()
+        mock_index.return_value = mock_engine
+        mock_load.side_effect = [
+            [{"query_id": "q1", "query": "test"}],
+            [{"query_id": "q1", "doc_id": "d1", "score": 1}],
+        ]
+        eval_instance = mock_eval.return_value
+        eval_instance.evaluate.return_value = {"ndcg@10": {10: 0.5}}
+
+        result = RetrievalEvaluator(evaluation).evaluate()
+
+        mock_index.assert_called_once()
+        mock_eval.assert_called_once()
+        assert result.metrics == {"ndcg@10": 0.5}


### PR DESCRIPTION
## Summary
- implement `RetrievalEvaluator` that downloads the BEIR `scifacts` dataset,
  indexes the corpus under `.cache-evals` and evaluates retrieval with
  `EvaluateRetrieval`
- document dataset usage in evaluation framework docs
- record the new evaluator in the changelog
- require the `datasets` package
- add unit test covering evaluator logic

## Testing
- `./check.sh`