### PR TITLE
Add dataset parameter to evaluator

### DIFF
--- a/docs/source/evaluation_framework.md
+++ b/docs/source/evaluation_framework.md
@@ -14,7 +14,7 @@ regressions over time.
 ## Key Components
 1. **Dataset management**
    - Use a small collection of documents and question/answer pairs (e.g. samples from the [BEIR](https://github.com/beir-datasets/beir) dataset).
-   - The retrieval evaluator downloads the `scifacts` dataset from Hugging Face and indexes the corpus under a dedicated `.cache-evals` directory.
+   - The retrieval evaluator downloads the `BeIR/scifact` dataset from Hugging Face and indexes the corpus under a dedicated `.cache-evals` directory. The dataset name is configurable to support additional BEIR collections.
    - Store datasets under `tests/data/` so evaluations run offline.
    - Pydantic models define dataset schema and evaluation configuration.
 

--- a/src/rag/evaluation/retrieval.py
+++ b/src/rag/evaluation/retrieval.py
@@ -15,17 +15,19 @@ from .types import Evaluation, EvaluationResult
 class RetrievalEvaluator:
     """Evaluator for retrieval metrics using BEIR datasets."""
 
-    def __init__(self, evaluation: Evaluation) -> None:
-        """Store evaluation configuration."""
+    def __init__(self, evaluation: Evaluation, dataset: str = "BeIR/scifact") -> None:
+        """Store evaluation configuration and dataset name."""
         self.evaluation = evaluation
+        self.dataset = dataset
 
     # Internal helpers -------------------------------------------------
     def _index_corpus(self, cache_dir: Path) -> RAGEngine:
-        """Download and index the Scifact corpus."""
+        """Download and index the selected corpus."""
         from datasets import load_dataset
 
-        dataset = load_dataset("BeIR/scifacts", "corpus", split="corpus")
-        docs_dir = cache_dir / "scifacts-corpus"
+        dataset = load_dataset(self.dataset, "corpus", split="corpus")
+        dataset_slug = self.dataset.rsplit("/", 1)[-1]
+        docs_dir = cache_dir / f"{dataset_slug}-corpus"
         docs_dir.mkdir(parents=True, exist_ok=True)
 
         for item in dataset:
@@ -70,8 +72,8 @@ class RetrievalEvaluator:
 
         engine = self._index_corpus(cache_dir)
 
-        queries = load_dataset("BeIR/scifacts", "queries", split="test")
-        qrels = load_dataset("BeIR/scifacts", "qrels", split="test")
+        queries = load_dataset(self.dataset, "queries", split="test")
+        qrels = load_dataset(self.dataset, "qrels", split="test")
 
         query_list = [dict(q) for q in queries]
         results = self._run_retrieval(engine, query_list, k=10)

--- a/tests/unit/evaluation/test_retrieval_evaluator.py
+++ b/tests/unit/evaluation/test_retrieval_evaluator.py
@@ -5,7 +5,7 @@ from rag.evaluation.types import Evaluation
 
 
 def test_retrieval_evaluator_uses_beir() -> None:
-    evaluation = Evaluation(category="retrieval", test="scifacts", metrics=["ndcg@10"])
+    evaluation = Evaluation(category="retrieval", test="BeIR/scifact", metrics=["ndcg@10"])
 
     with (
         patch.object(RetrievalEvaluator, "_index_corpus") as mock_index,
@@ -25,4 +25,6 @@ def test_retrieval_evaluator_uses_beir() -> None:
 
         mock_index.assert_called_once()
         mock_eval.assert_called_once()
+        mock_load.assert_any_call("BeIR/scifact", "queries", split="test")
+        mock_load.assert_any_call("BeIR/scifact", "qrels", split="test")
         assert result.metrics == {"ndcg@10": 0.5}


### PR DESCRIPTION
## Summary
- allow BEIR dataset name to be specified in `RetrievalEvaluator`
- use `BeIR/scifact` dataset instead of `BeIR/scifacts`
- update docs and unit tests

## Testing
- `./check.sh`