### PR TITLE
Fix retrieval evaluator qrels dataset

### DIFF
--- a/docs/source/evaluation_framework.md
+++ b/docs/source/evaluation_framework.md
@@ -14,7 +14,7 @@ regressions over time.
 ## Key Components
 1. **Dataset management**
    - Use a small collection of documents and question/answer pairs (e.g. samples from the [BEIR](https://github.com/beir-datasets/beir) dataset).
-   - The retrieval evaluator downloads the `BeIR/scifact` dataset from Hugging Face and indexes the corpus under a dedicated `.cache-evals` directory. The dataset name is configurable to support additional BEIR collections.
+  - The retrieval evaluator downloads the `BeIR/scifact` dataset from Hugging Face and indexes the corpus under a dedicated `.cache-evals` directory. The dataset name is configurable to support additional BEIR collections. Qrels are fetched from the companion `scifact-qrels` dataset by merging both the `train` and `test` splits.
    - Store datasets under `tests/data/` so evaluations run offline.
    - Pydantic models define dataset schema and evaluation configuration.
 

--- a/src/rag/evaluation/retrieval.py
+++ b/src/rag/evaluation/retrieval.py
@@ -73,7 +73,11 @@ class RetrievalEvaluator:
         engine = self._index_corpus(cache_dir)
 
         queries = load_dataset(self.dataset, "queries")
-        qrels = load_dataset(self.dataset, "qrels", split="test")
+        dataset_slug = self.dataset.rsplit("/", 1)[-1]
+        qrels_ds = f"{dataset_slug}-qrels"
+        qrels_train = load_dataset(qrels_ds, split="train")
+        qrels_test = load_dataset(qrels_ds, split="test")
+        qrels = list(qrels_train) + list(qrels_test)
 
         query_list = [dict(q) for q in queries]
         results = self._run_retrieval(engine, query_list, k=10)

--- a/tests/unit/evaluation/test_retrieval_evaluator.py
+++ b/tests/unit/evaluation/test_retrieval_evaluator.py
@@ -5,7 +5,9 @@ from rag.evaluation.types import Evaluation
 
 
 def test_retrieval_evaluator_uses_beir() -> None:
-    evaluation = Evaluation(category="retrieval", test="BeIR/scifact", metrics=["ndcg@10"])
+    evaluation = Evaluation(
+        category="retrieval", test="BeIR/scifact", metrics=["ndcg@10"]
+    )
 
     with (
         patch.object(RetrievalEvaluator, "_index_corpus") as mock_index,
@@ -17,6 +19,7 @@ def test_retrieval_evaluator_uses_beir() -> None:
         mock_load.side_effect = [
             [{"query_id": "q1", "query": "test"}],
             [{"query_id": "q1", "doc_id": "d1", "score": 1}],
+            [{"query_id": "q1", "doc_id": "d1", "score": 1}],
         ]
         eval_instance = mock_eval.return_value
         eval_instance.evaluate.return_value = {"ndcg@10": {10: 0.5}}
@@ -25,6 +28,7 @@ def test_retrieval_evaluator_uses_beir() -> None:
 
         mock_index.assert_called_once()
         mock_eval.assert_called_once()
-        mock_load.assert_any_call("BeIR/scifact", "queries", split="test")
-        mock_load.assert_any_call("BeIR/scifact", "qrels", split="test")
+        mock_load.assert_any_call("BeIR/scifact", "queries")
+        mock_load.assert_any_call("scifact-qrels", split="train")
+        mock_load.assert_any_call("scifact-qrels", split="test")
         assert result.metrics == {"ndcg@10": 0.5}


### PR DESCRIPTION
## Summary
- load qrels from `<dataset>-qrels` and combine train/test splits
- update documentation for qrels source
- adjust retrieval evaluator unit test

## Testing
- `./check.sh`

------
https://chatgpt.com/codex/tasks/task_e_683b86c95714832ebcbcb35b4c2a6ca4