### PR TITLE
Fix retrieval evaluator test split

### DIFF
--- a/src/rag/evaluation/retrieval.py
+++ b/src/rag/evaluation/retrieval.py
@@ -80,12 +80,10 @@ class RetrievalEvaluator:
         engine = self._index_corpus(cache_dir)
         self._logger.debug("Corpus indexed")
 
-        queries = load_dataset(self.dataset, "queries")
+        queries = load_dataset(self.dataset, "queries", split="test")
         self._logger.debug(f"Loaded {len(queries)} queries")
         qrels_ds = f"{self.dataset}-qrels"
-        qrels_train = load_dataset(qrels_ds, split="train")
-        qrels_test = load_dataset(qrels_ds, split="test")
-        qrels = list(qrels_train) + list(qrels_test)
+        qrels = load_dataset(qrels_ds, split="test")
 
         query_list = [dict(q) for q in queries]
         results = self._run_retrieval(engine, query_list, k=10)

--- a/tests/unit/evaluation/test_retrieval_evaluator.py
+++ b/tests/unit/evaluation/test_retrieval_evaluator.py
@@ -19,7 +19,6 @@ def test_retrieval_evaluator_uses_beir() -> None:
         mock_load.side_effect = [
             [{"query_id": "q1", "query": "test"}],
             [{"query_id": "q1", "doc_id": "d1", "score": 1}],
-            [{"query_id": "q1", "doc_id": "d1", "score": 1}],
         ]
         eval_instance = mock_eval.return_value
         eval_instance.evaluate.return_value = {"ndcg@10": {10: 0.5}}
@@ -28,7 +27,6 @@ def test_retrieval_evaluator_uses_beir() -> None:
 
         mock_index.assert_called_once()
         mock_eval.assert_called_once()
-        mock_load.assert_any_call("BeIR/scifact", "queries")
-        mock_load.assert_any_call("BeIR/scifact-qrels", split="train")
+        mock_load.assert_any_call("BeIR/scifact", "queries", split="test")
         mock_load.assert_any_call("BeIR/scifact-qrels", split="test")
         assert result.metrics == {"ndcg@10": 0.5}


### PR DESCRIPTION
## Summary
- restrict retrieval evaluator to only use the test split
- update unit test accordingly

## Testing
- `./check.sh`

------
https://chatgpt.com/codex/tasks/task_e_683dd64a9ae4832e974ea5979825b684