### PR TITLE
Add multi-dataset retrieval evaluation

### DIFF
--- a/docs/source/evaluation_framework.md
+++ b/docs/source/evaluation_framework.md
@@ -14,7 +14,11 @@ regressions over time.
 ## Key Components
 1. **Dataset management**
    - Use a small collection of documents and question/answer pairs (e.g. samples from the [BEIR](https://github.com/beir-datasets/beir) dataset).
-  - The retrieval evaluator downloads the `BeIR/scifact` dataset from Hugging Face and indexes the corpus under a dedicated `.cache-evals` directory. The dataset name is configurable to support additional BEIR collections. Qrels are fetched from the companion `scifact-qrels` dataset by merging both the `train` and `test` splits.
+  - The retrieval evaluator downloads BEIR datasets (e.g. `BeIR/scifact`) from
+    Hugging Face and indexes the corpus under a dedicated `.cache-evals`
+    directory. The dataset name is configurable to support additional
+    collections. Qrels are fetched from the companion `<dataset>-qrels` dataset
+    by merging both the `train` and `test` splits.
    - Store datasets under `tests/data/` so evaluations run offline.
    - Pydantic models define dataset schema and evaluation configuration.
 

--- a/src/rag/cli/cli.py
+++ b/src/rag/cli/cli.py
@@ -92,9 +92,29 @@ DEFAULT_CHAT_MODEL = "gpt-4"
 DEFAULT_EVALUATIONS = [
     Evaluation(
         category="retrieval",
-        test="dummy",
+        test="BeIR/scifact",
         metrics=["NDCG@10", "MAP@10", "MRR@10", "Recall@10", "Precision@10"],
-    )
+    ),
+    Evaluation(
+        category="retrieval",
+        test="BeIR/scidocs",
+        metrics=["NDCG@10", "MAP@10", "MRR@10", "Recall@10", "Precision@10"],
+    ),
+    Evaluation(
+        category="retrieval",
+        test="BeIR/trec-covid",
+        metrics=["NDCG@10", "MAP@10", "MRR@10", "Recall@10", "Precision@10"],
+    ),
+    Evaluation(
+        category="retrieval",
+        test="BeIR/fever",
+        metrics=["NDCG@10", "MAP@10", "MRR@10", "Recall@10", "Precision@10"],
+    ),
+    Evaluation(
+        category="retrieval",
+        test="BeIR/fiqa",
+        metrics=["NDCG@10", "MAP@10", "MRR@10", "Recall@10", "Precision@10"],
+    ),
 ]
 
 

--- a/src/rag/evaluation/retrieval.py
+++ b/src/rag/evaluation/retrieval.py
@@ -17,10 +17,19 @@ from .types import Evaluation, EvaluationResult
 class RetrievalEvaluator:
     """Evaluator for retrieval metrics using BEIR datasets."""
 
-    def __init__(self, evaluation: Evaluation, dataset: str = "BeIR/scifact") -> None:
-        """Store evaluation configuration and dataset name."""
+    def __init__(self, evaluation: Evaluation, dataset: str | None = None) -> None:
+        """Store evaluation configuration and dataset name.
+
+        Args:
+            evaluation: Evaluation settings including the dataset name in
+                ``evaluation.test``.
+            dataset: Optional explicit dataset override. If ``None`` the value
+                from ``evaluation.test`` is used. Defaults to ``BeIR/scifact``
+                when neither is provided.
+        """
+
         self.evaluation = evaluation
-        self.dataset = dataset
+        self.dataset = dataset or evaluation.test or "BeIR/scifact"
 
         self._logger = get_logger()
 

--- a/tests/unit/evaluation/test_retrieval_evaluator.py
+++ b/tests/unit/evaluation/test_retrieval_evaluator.py
@@ -6,7 +6,9 @@ from rag.evaluation.types import Evaluation
 
 def test_retrieval_evaluator_uses_beir() -> None:
     evaluation = Evaluation(
-        category="retrieval", test="BeIR/scifact", metrics=["ndcg@10"]
+        category="retrieval",
+        test="BeIR/fiqa",
+        metrics=["ndcg@10"],
     )
 
     with (
@@ -27,6 +29,6 @@ def test_retrieval_evaluator_uses_beir() -> None:
 
         mock_index.assert_called_once()
         mock_eval.assert_called_once()
-        mock_load.assert_any_call("BeIR/scifact", "queries", split="test")
-        mock_load.assert_any_call("BeIR/scifact-qrels", split="test")
+        mock_load.assert_any_call("BeIR/fiqa", "queries")
+        mock_load.assert_any_call("BeIR/fiqa-qrels", split="test")
         assert result.metrics == {"ndcg@10": 0.5}


### PR DESCRIPTION
## Summary
- run RetrievalEvaluator for five BEIR datasets
- infer dataset from `Evaluation.test`
- document evaluation dataset handling
- update unit tests

## Testing
- `./check.sh`

------
https://chatgpt.com/codex/tasks/task_e_683dd2a23250832eaa293e0cca86212f