### PR TITLE
Enable concurrent file indexing and add worker-aware logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Async embedding workers using `aiostream` for concurrent processing
 - `--max-workers` CLI flag to control async concurrency
 - `--async-batching/--sync-batching` flag to control embedding batching mode
+- Concurrent file indexing with per-worker log IDs
 - Incremental indexing using chunk hashes to skip unchanged chunks
 - Structured logging using structlog with Rich console output
 - `--log-file` CLI option to direct logs to a file


### PR DESCRIPTION
## Summary
- process files concurrently when indexing directories
- include worker thread names in log entries

## Testing
- `./check.sh` *(fails: tests/unit/cli/test_debug_option.py::test_debug_logs_emitted)*

------
https://chatgpt.com/codex/tasks/task_e_683e175c104c832e9d208614d6d2f873